### PR TITLE
refactor: align tag text vertically

### DIFF
--- a/src/react/components/common/tagInput/tagInput.scss
+++ b/src/react/components/common/tagInput/tagInput.scss
@@ -121,7 +121,7 @@ $tagInputWidth: 250px;
             text-overflow: ellipsis;
             white-space: nowrap;
             align-items: center;
-            padding: 0px 0px 3px 0px; 
+            padding: 0px 0px 5px 0px; 
         }
     }
 


### PR DESCRIPTION
align tag text vertically. Currently the text is aligned too low in the
tag input