### PR TITLE
fix: fix ui fabric contextual menu misbehavior after dismiss with ESC…

### DIFF
--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -162,7 +162,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
             scopedSettings: {},
         };
 
-        const { selectedTag } = this.state;
+        const { selectedTag, tagOperation } = this.state;
         const selectedTagRef = selectedTag ? this.tagItemRefs.get(selectedTag.name).getTagNameRef() : null;
 
         return (
@@ -200,13 +200,15 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                     <div className="tag-input-items">
                         {this.renderTagItems()}
                         <Customizer {...dark}>
-                            <ContextualMenu
-                                className="tag-input-contextual-menu"
-                                items={this.getContextualMenuItems()}
-                                hidden={!selectedTagRef || this.state.tagOperation !== TagOperationMode.ContextualMenu}
-                                target={selectedTagRef}
-                                onDismiss={this.onHideContextualMenu}
-                            />
+                            {
+                                tagOperation === TagOperationMode.ContextualMenu && selectedTagRef &&
+                                <ContextualMenu
+                                    className="tag-input-contextual-menu"
+                                    items={this.getContextualMenuItems()}
+                                    target={selectedTagRef}
+                                    onDismiss={this.onHideContextualMenu}
+                                />
+                            }
                         </Customizer>
                         {this.getColorPickerPortal()}
                     </div>


### PR DESCRIPTION
It looks like there is some bug in ui fabric contextual menu. If user active the context menu with keyboard and dismiss with ESCAPE key, the dropdown button will keeping getting focus from input element.
Fix: not persist contextual menu in DOM tree and create new one when we need to show the menu.

Reproduce the bug without this fix.
1. Active contextual menu with keyboard.
2. Dismiss the contextual menu with ESCAPE.
3. Select rename from the contextual menu.

Actual result:
Dropdown button will get the focus
Expect result:
Input element will get the focus