### PR TITLE
fix: display detailed error message when fetch

### DIFF
--- a/src/react/components/pages/predict/predictPage.tsx
+++ b/src/react/components/pages/predict/predictPage.tsx
@@ -358,7 +358,7 @@ export default class PredictPage extends React.Component<IPredictPageProps, IPre
                     isFetching: false,
                     shouldShowAlert: true,
                     alertTitle: "Failed to fetch",
-                    alertMessage: response.status.toString(),
+                    alertMessage: response.status.toString() + " " + response.statusText,
                     isPredicting: false,
                 });
                 return;
@@ -407,7 +407,7 @@ export default class PredictPage extends React.Component<IPredictPageProps, IPre
                 isFetching: false,
                 shouldShowAlert: true,
                 alertTitle: "Fetch failed",
-                alertMessage: "Couldn't fetch file",
+                alertMessage: "Network error or Cross-Origin Resource Sharing (CORS) is not configured server-side",
             });
             return;
         });


### PR DESCRIPTION
display detailed error message when fetch fails