### PR TITLE
fix: on overflowing .app-content div when on create

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -118,6 +118,7 @@
       flex-grow: 1;
       display: flex;
       flex-direction: column;
+      overflow-y: scroll;
   }
 }
 


### PR DESCRIPTION
This is a test: first commit to repo + small bugfix on #192 