### PR TITLE
Stew ro/check tag type and region catagory compatibility

### DIFF
--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -472,16 +472,13 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
             if (selectedRegions && selectedRegions.length && onTagClick) {
                 const { category } = selectedRegions[0];
                 const { format, type, documentCount } = tag;
-                switch (true) {
-                    case this.isSelectionMark(category) && this.isSelectionMark(type):
-                    case !this.isSelectionMark(category) && !this.isSelectionMark(type):
-                    case documentCount === 0 && type === FieldType.String && format === FieldFormat.NotSpecified:
+                const tagCatagory = this.getTagCatagory(type);
+                if (tagCatagory === category ||
+                    (documentCount === 0 && type === FieldType.String && format === FieldFormat.NotSpecified)) {
                         onTagClick(tag);
                         deselect = false;
-                        break;
-                    default:
-                        toast.warn(strings.tags.warnings.notCompatibleTagType);
-                        break;
+                } else {
+                    toast.warn(strings.tags.warnings.notCompatibleTagType);
                 }
             }
             this.setState({
@@ -489,6 +486,15 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                 tagOperation,
             });
 
+        }
+    }
+
+    private getTagCatagory = (tagType: string) => {
+        switch (tagType) {
+            case FieldType.SelectionMark:
+                return "checkbox";
+            default:
+                return "text";
         }
     }
 

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -472,8 +472,8 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
             if (selectedRegions && selectedRegions.length && onTagClick) {
                 const { category } = selectedRegions[0];
                 const { format, type, documentCount } = tag;
-                const tagCatagory = this.getTagCatagory(type);
-                if (tagCatagory === category ||
+                const tagCategory = this.getTagCategory(type);
+                if (tagCategory === category ||
                     (documentCount === 0 && type === FieldType.String && format === FieldFormat.NotSpecified)) {
                         onTagClick(tag);
                         deselect = false;
@@ -489,14 +489,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
         }
     }
 
-    private getTagCatagory = (tagType: string) => {
-        switch (tagType) {
-            case FieldType.SelectionMark:
-                return "checkbox";
-            default:
-                return "text";
-        }
-    }
+    private getTagCategory = (tagType: string) => tagType === FieldType.SelectionMark ? "checkbox" : "text";
 
     private onSearchKeyDown = (event: KeyboardEvent): void => {
         if (event.key === "Escape") {

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -489,7 +489,14 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
         }
     }
 
-    private getTagCategory = (tagType: string) => tagType === FieldType.SelectionMark ? "checkbox" : "text";
+    private getTagCategory = (tagType: string) => {
+        switch (tagType) {
+            case FieldType.SelectionMark:
+                return "checkbox";
+            default:
+                return "text";
+        }
+    }
 
     private onSearchKeyDown = (event: KeyboardEvent): void => {
         if (event.key === "Escape") {


### PR DESCRIPTION
The only condition needed is: "selected region equals tag category or tag is free" right?

`!this.isSelectionMark(selectedRegions[0].category) && !this.isSelectionMark(tag.type)`
will become a problem