### PR TITLE
fix: set document count to 1 when inffering tag type

### DIFF
--- a/src/react/components/pages/connections/connectionForm.tsx
+++ b/src/react/components/pages/connections/connectionForm.tsx
@@ -157,6 +157,18 @@ export default class ConnectionForm extends React.Component<IConnectionFormProps
             errors.providerType.addError("is a required property");
         }
 
+        if (connection.providerOptions && connection.providerOptions["sas"] && errors.providerOptions["sas"]) {
+            const urlRegex = new RegExp(/^(\s*)?(https:\/\/)([^\s])+(\s*)?$/);
+            if (urlRegex.test(connection.providerOptions["sas"])) {
+                const urlWithQueryRegex = new RegExp(/\?.+\=.+/);
+                if (!urlWithQueryRegex.test(connection.providerOptions["sas"])) {
+                    errors.providerOptions["sas"].addError("should include SAS token in query");
+                }
+            } else {
+                errors.providerOptions["sas"].addError("should match URI format");
+            }
+        }
+
         if (this.state.classNames.indexOf("was-validated") === -1) {
             this.setState({
                 classNames: [...this.state.classNames, "was-validated"],

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -329,9 +329,10 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
         const newTag = {
             ...tag,
+            documentCount: 1,
             type : fieldType,
             format : FieldFormat.NotSpecified,
-        };
+        } as ITag;
         this.props.onTagChanged(tag, newTag);
     }
 


### PR DESCRIPTION
applyTag is calling updateRegions which calls **async** onAssetMetadataChanged. So when we call setTags, it is passed the project.tags before the tags have updated

Ideally we would pass the updated tags to setTags. This is a workaround