### PR TITLE
fix: overlapping left split pane

### DIFF
--- a/src/react/components/pages/editorPage/editorPage.scss
+++ b/src/react/components/pages/editorPage/editorPage.scss
@@ -271,16 +271,16 @@ canvas {
 }
 
 .Resizer.vertical {
-  width: 11px;
-  margin: 0 -5px;
-  border-left: 5px solid rgba(255, 255, 255, 0);
-  border-right: 5px solid rgba(255, 255, 255, 0);
+  width: 6px;
+  border-left: 3px solid rgba(255, 255, 255, 0);
+  border-right: 3px solid rgba(255, 255, 255, 0);
+  background-color: rgba(255, 255, 255, 0);
   cursor: col-resize;
 }
 
 .Resizer.vertical:hover {
-  border-left: 5px solid rgba(0, 0, 0, 0.5);
-  border-right: 5px solid rgba(0, 0, 0, 0.5);
+  border-left: 3px solid rgba(0, 0, 0, 0.5);
+  border-right:3px solid rgba(0, 0, 0, 0.5);
 }
 .Resizer.disabled {
   cursor: not-allowed;


### PR DESCRIPTION
fix on: Split pane overlapping with asset preview scrollbar #250
