### PR TITLE
Style for the table view

### DIFF
--- a/src/react/components/pages/editorPage/tableView.scss
+++ b/src/react/components/pages/editorPage/tableView.scss
@@ -1,37 +1,35 @@
 @import "../../../../assets/sass/theme.scss";
 @import "../../common/common.scss";
 
-.viewed-table {
-    border: 1.2px solid rgba(255,255,255, 0.9);
-    td {
-        border: 0.6px solid rgba(255,255,255, 0.7);
-        min-width: 80px;
-        padding: 8px 16px 8px 8px;
+.table-view-container {
+    direction: rtl;
+    margin: 1rem;
+    max-height: 85vh;
+    max-width: 85vw;
+    .viewed-table {
+        direction: ltr;
+        margin: 0.25rem 0.75rem;
+        td {
+            border: 2px solid #8D8D8D;
+            min-width: 80px;
+            padding: 0.5rem 1rem;
+        }
+        td:empty::after {
+            content: "\00a0";
+        }
     }
-    td:empty::after {
-        content: "\00a0";
-    }
-
 }
 
 .close-modal {
     right: 0px;
     top: 0px;
-    padding: 0 4px;
-    margin-right: 3px;
-    margin-top: 2px;
+    margin: 0.75rem 1rem;
     position: fixed;
     color: #fff;
     &:hover {
         color: $lighter-5;
         cursor: pointer;
     }
-}
-
-.table-view-container {
-    max-height: 85vh;
-    max-width: 85vw;
-
 }
 
 .table-view-scrollable-content {

--- a/src/react/components/pages/editorPage/tableView.scss
+++ b/src/react/components/pages/editorPage/tableView.scss
@@ -34,7 +34,7 @@
 
 }
 
-.table-view-scollable-content {
+.table-view-scrollable-content {
     margin: 25px 25px;
-    max-height: 65vh;    
+    max-height: 65vh;
 }

--- a/src/react/components/pages/editorPage/tableView.scss
+++ b/src/react/components/pages/editorPage/tableView.scss
@@ -35,6 +35,6 @@
 }
 
 .table-view-scrollable-content {
-    margin: 25px 25px;
+    margin: 25px;
     max-height: 65vh;
 }

--- a/src/react/components/pages/editorPage/tableView.scss
+++ b/src/react/components/pages/editorPage/tableView.scss
@@ -2,12 +2,10 @@
 @import "../../common/common.scss";
 
 .table-view-container {
-    direction: rtl;
-    margin: 1rem;
+    margin-left: 0.5rem;
     max-height: 85vh;
     max-width: 85vw;
     .viewed-table {
-        direction: ltr;
         margin: 0.25rem 0.75rem;
         td {
             border: 2px solid #8D8D8D;
@@ -21,10 +19,9 @@
 }
 
 .close-modal {
-    right: 0px;
-    top: 0px;
-    margin: 0.75rem 1rem;
     position: fixed;
+    top: 10px;
+    right: 13px;
     color: #fff;
     &:hover {
         color: $lighter-5;
@@ -33,6 +30,6 @@
 }
 
 .table-view-scrollable-content {
-    margin: 25px;
+    margin: 2.25rem 1rem;
     max-height: 65vh;
 }

--- a/src/react/components/pages/editorPage/tableView.tsx
+++ b/src/react/components/pages/editorPage/tableView.tsx
@@ -52,7 +52,6 @@ export const TableView: React.FunctionComponent<ITableViewProps> = (props) => {
                 isOpen={props.tableToView !== null}
                 isModeless={true}
                 dragOptions={dragOptions}
-                containerClassName={"table-view-container"}
                 scrollableContentClassName={"table-view-scrollable-content"}
             >
             <FontIcon
@@ -61,11 +60,13 @@ export const TableView: React.FunctionComponent<ITableViewProps> = (props) => {
                 iconName="Cancel"
                 onClick={props.handleTableViewClose}
                 />
-            <table className="viewed-table">
-                <tbody>
-                    {getTableBody()}
-                </tbody>
-            </table>
+                <div className="table-view-container">
+                    <table className="viewed-table">
+                        <tbody>
+                            {getTableBody()}
+                        </tbody>
+                    </table>
+                </div>
             </Modal>
         </Customizer>
     );

--- a/src/react/components/pages/editorPage/tableView.tsx
+++ b/src/react/components/pages/editorPage/tableView.tsx
@@ -53,14 +53,14 @@ export const TableView: React.FunctionComponent<ITableViewProps> = (props) => {
                 isModeless={true}
                 dragOptions={dragOptions}
                 containerClassName={"table-view-container"}
-                scrollableContentClassName={"table-view-scollable-content"}
+                scrollableContentClassName={"table-view-scrollable-content"}
             >
             <FontIcon
                 className="close-modal"
                 role="button"
                 iconName="Cancel"
                 onClick={props.handleTableViewClose}
-            />
+                />
             <table className="viewed-table">
                 <tbody>
                     {getTableBody()}


### PR DESCRIPTION
I adapted table style to be more align with overall app design:
-add horizontal padding for cells content
- make borders less prominent - darker and bit bolder (for readability )
- moved to the left and spaced out scrollbar (it's not touching  table anymore)
- add some space to close button from the edges (too close in my opinion)
...and fix some redundant  code and misspelling
After:
![Screen Shot 2020-05-22 at 1 14 45 PM](https://user-images.githubusercontent.com/64093224/82707170-60865100-9c30-11ea-8e2a-8ec6e2fa5a37.png)
 

Before: 
<img width="1112" alt="Screen Shot 2020-05-22 at 1 36 14 PM" src="https://user-images.githubusercontent.com/64093224/82707624-4d27b580-9c31-11ea-9e4b-077d34c83240.png">

