### PR TITLE
refactor: migrating to Fluent UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "main": "build/main.js",
     "dependencies": {
         "@azure/storage-blob": "10.3.0",
+        "@fluentui/react": "^7.117.2",
         "axios": "^0.19.0",
         "bootstrap": "^4.4.1",
         "chart.js": "^2.9.3",
         "exif-js": "^2.3.0",
         "lodash": "^4.17.15",
-        "office-ui-fabric-react": "^7.86.1",
         "ol": "^5.3.3",
         "rc-align": "^2.4.5",
         "rc-checkbox": "^2.1.8",

--- a/src/common/themes.ts
+++ b/src/common/themes.ts
@@ -1,4 +1,4 @@
-import {createTheme} from "office-ui-fabric-react";
+import {createTheme} from "@fluentui/react";
 
 const greenButtonPalette = {
     themePrimary: "#78ad0e",

--- a/src/react/components/common/alert/alert.tsx
+++ b/src/react/components/common/alert/alert.tsx
@@ -12,7 +12,7 @@ import {
     ICustomizations,
     ITheme,
     PrimaryButton,
-} from "office-ui-fabric-react";
+} from "@fluentui/react";
 /**
  * Properties for Alert Component
  * @member closeButtonText - Text displayed on 'Close' button. Default 'OK'

--- a/src/react/components/common/arrayField/arrayFieldTemplate.tsx
+++ b/src/react/components/common/arrayField/arrayFieldTemplate.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from "react";
 import { ArrayFieldTemplateProps } from "react-jsonschema-form";
-import { FontIcon, PrimaryButton } from "office-ui-fabric-react";
+import { FontIcon, PrimaryButton } from "@fluentui/react";
 import { strings } from "../../../../common/strings";
 import { getPrimaryBlueTheme, getPrimaryGreenTheme } from "../../../../common/themes";
 

--- a/src/react/components/common/assetPreview/assetPreview.tsx
+++ b/src/react/components/common/assetPreview/assetPreview.tsx
@@ -7,8 +7,8 @@ import { strings } from "../../../../common/strings";
 import { ImageAsset } from "./imageAsset";
 import { PDFAsset } from "./pdfAsset";
 import { TiffAsset } from "./tiffAsset";
-import { Spinner, SpinnerSize } from "office-ui-fabric-react/lib/Spinner";
-import { Label } from "office-ui-fabric-react/lib/Label";
+import { Spinner, SpinnerSize } from "@fluentui/react/lib/Spinner";
+import { Label } from "@fluentui/react/lib/Label";
 
 export interface IGenericContentSource {
     width: number;

--- a/src/react/components/common/condensedList/condensedList.tsx
+++ b/src/react/components/common/condensedList/condensedList.tsx
@@ -3,8 +3,8 @@
 
 import React, { SyntheticEvent } from "react";
 import { Link } from "react-router-dom";
-import { FontIcon } from "office-ui-fabric-react";
-import { Spinner, SpinnerSize } from "office-ui-fabric-react/lib/Spinner";
+import { FontIcon } from "@fluentui/react";
+import { Spinner, SpinnerSize } from "@fluentui/react/lib/Spinner";
 import "./condensedList.scss";
 
 /**

--- a/src/react/components/common/confirm/confirm.tsx
+++ b/src/react/components/common/confirm/confirm.tsx
@@ -11,7 +11,7 @@ import {
     ITheme,
     PrimaryButton,
     DefaultButton,
-} from "office-ui-fabric-react";
+} from "@fluentui/react";
 import { MessageFormatHandler } from "../messageBox/messageBox";
 import { getDarkTheme } from "../../../../common/themes";
 

--- a/src/react/components/common/connectionPicker/connectionPicker.tsx
+++ b/src/react/components/common/connectionPicker/connectionPicker.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 import { IConnection } from "../../../../models/applicationState";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { DefaultButton } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import { getPrimaryGreyTheme } from "../../../../common/themes";
 
 /**

--- a/src/react/components/common/protectedInput/protectedInput.tsx
+++ b/src/react/components/common/protectedInput/protectedInput.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon, DefaultButton } from "office-ui-fabric-react";
+import { FontIcon, DefaultButton } from "@fluentui/react";
 import { getPrimaryGreyTheme } from "../../../../common/themes";
 
 /**

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -11,7 +11,7 @@ import {
     ICustomizations,
     Spinner,
     SpinnerSize,
-} from "office-ui-fabric-react";
+} from "@fluentui/react";
 import { strings } from "../../../../common/strings";
 import { getDarkTheme } from "../../../../common/themes";
 import { AlignPortal } from "../align/alignPortal";

--- a/src/react/components/common/tagInput/tagInputItem.tsx
+++ b/src/react/components/common/tagInput/tagInputItem.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React, { MouseEvent } from "react";
-import { FontIcon, IconButton } from "office-ui-fabric-react";
+import { FontIcon, IconButton } from "@fluentui/react";
 import { ITag, ILabel, FieldType, FieldFormat } from "../../../../models/applicationState";
 import { strings } from "../../../../common/strings";
 import TagInputItemLabel from "./tagInputItemLabel";

--- a/src/react/components/common/tagInput/tagInputToolbar.tsx
+++ b/src/react/components/common/tagInput/tagInputToolbar.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { IconButton } from "office-ui-fabric-react";
+import { IconButton } from "@fluentui/react";
 import { strings } from "../../../../common/strings";
 import { ITag } from "../../../../models/applicationState";
 

--- a/src/react/components/pages/appSettings/appSettingsForm.tsx
+++ b/src/react/components/pages/appSettings/appSettingsForm.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { strings, addLocValues } from "../../../../common/strings";
 import Form, { FormValidation } from "react-jsonschema-form";
 import { ObjectFieldTemplate } from "../../common/objectField/objectFieldTemplate";
@@ -12,7 +12,7 @@ import { IAppSettings } from "../../../../models/applicationState";
 import { ProtectedInput } from "../../common/protectedInput/protectedInput";
 import { CustomField } from "../../common/customField/customField";
 import { generateKey } from "../../../../common/crypto";
-import { PrimaryButton } from "office-ui-fabric-react";
+import { PrimaryButton } from "@fluentui/react";
 import { getPrimaryGreenTheme, getPrimaryGreyTheme } from "../../../../common/themes";
 // tslint:disable-next-line:no-var-requires
 const formSchema = addLocValues(require("./appSettingsForm.json"));

--- a/src/react/components/pages/connections/connectionForm.tsx
+++ b/src/react/components/pages/connections/connectionForm.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import Form, { Widget, IChangeEvent, FormValidation } from "react-jsonschema-form";
-import { FontIcon, PrimaryButton} from "office-ui-fabric-react";
+import { FontIcon, PrimaryButton} from "@fluentui/react";
 import { IConnection } from "../../../../models/applicationState";
 import { strings, addLocValues } from "../../../../common/strings";
 import CustomFieldTemplate from "../../common/customField/customFieldTemplate";

--- a/src/react/components/pages/connections/connectionItem.tsx
+++ b/src/react/components/pages/connections/connectionItem.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { FontIcon, IconButton } from "office-ui-fabric-react";
+import { FontIcon, IconButton } from "@fluentui/react";
 import { strings } from "../../../../common/strings";
 import "../../../../App.scss";
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import React, { ReactElement } from "react";
-import { Spinner, SpinnerSize } from "office-ui-fabric-react/lib/Spinner";
-import { Label } from "office-ui-fabric-react/lib/Label";
-import { IconButton } from "office-ui-fabric-react/lib/Button";
+import { Spinner, SpinnerSize } from "@fluentui/react/lib/Spinner";
+import { Label } from "@fluentui/react/lib/Label";
+import { IconButton } from "@fluentui/react/lib/Button";
 import {
     EditorMode, IAssetMetadata,
     IProject, IRegion, RegionType,
@@ -33,7 +33,7 @@ import HtmlFileReader from "../../../../common/htmlFileReader";
 import { parseTiffData, renderTiffToCanvas, loadImageToCanvas } from "../../../../common/utils";
 import { constants } from "../../../../common/constants";
 import { CanvasCommandBar } from "./canvasCommandBar";
-import { TooltipHost, ITooltipHostStyles } from "office-ui-fabric-react";
+import { TooltipHost, ITooltipHostStyles } from "@fluentui/react";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = constants.pdfjsWorkerSrc(pdfjsLib.version);
 const cMapUrl = constants.pdfjsCMapUrl(pdfjsLib.version);

--- a/src/react/components/pages/editorPage/canvasCommandBar.tsx
+++ b/src/react/components/pages/editorPage/canvasCommandBar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { CommandBar, ICommandBarItemProps } from "office-ui-fabric-react/lib/CommandBar";
-import { ICustomizations, Customizer } from "office-ui-fabric-react/lib/Utilities";
+import { CommandBar, ICommandBarItemProps } from "@fluentui/react/lib/CommandBar";
+import { ICustomizations, Customizer } from "@fluentui/react/lib/Utilities";
 import { getDarkGreyTheme } from "../../../../common/themes";
 
 interface ICanvasCommandBarProps {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -7,7 +7,7 @@ import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 import SplitPane from "react-split-pane";
 import { bindActionCreators } from "redux";
-import { PrimaryButton } from "office-ui-fabric-react";
+import { PrimaryButton } from "@fluentui/react";
 import HtmlFileReader from "../../../../common/htmlFileReader";
 import { strings } from "../../../../common/strings";
 import {
@@ -35,7 +35,7 @@ import { OCRService } from "../../../../services/ocrService";
 import { throttle } from "../../../../common/utils";
 import { constants } from "../../../../common/constants";
 import PreventLeaving from "../../common/preventLeaving/preventLeaving";
-import { Spinner, SpinnerSize } from "office-ui-fabric-react/lib/Spinner";
+import { Spinner, SpinnerSize } from "@fluentui/react/lib/Spinner";
 import { getPrimaryGreenTheme, getPrimaryRedTheme } from "../../../../common/themes";
 import { SkipButton } from "../../shell/skipButton";
 

--- a/src/react/components/pages/editorPage/editorSideBar.tsx
+++ b/src/react/components/pages/editorPage/editorSideBar.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { AutoSizer, List } from "react-virtualized";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { IAsset, AssetState, ISize } from "../../../../models/applicationState";
 import {AssetPreview, ContentSource} from "../../common/assetPreview/assetPreview";
 import { strings } from "../../../../common/strings";

--- a/src/react/components/pages/editorPage/tableView.tsx
+++ b/src/react/components/pages/editorPage/tableView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ICustomizations, Customizer, ContextualMenu, IDragOptions, Modal, FontIcon } from "office-ui-fabric-react";
+import { ICustomizations, Customizer, ContextualMenu, IDragOptions, Modal, FontIcon } from "@fluentui/react";
 import { getDarkGreyTheme } from "../../../../common/themes";
 import "./tableView.scss";
 

--- a/src/react/components/pages/homepage/homePage.tsx
+++ b/src/react/components/pages/homepage/homePage.tsx
@@ -5,7 +5,7 @@ import React, { SyntheticEvent } from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 import { bindActionCreators } from "redux";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { strings, interpolate } from "../../../../common/strings";
 import { getPrimaryRedTheme } from "../../../../common/themes";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";

--- a/src/react/components/pages/homepage/recentProjectItem.tsx
+++ b/src/react/components/pages/homepage/recentProjectItem.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon, IconButton } from "office-ui-fabric-react";
+import { FontIcon, IconButton } from "@fluentui/react";
 import { strings } from "../../../../common/strings";
 import "../../../../App.scss";
 

--- a/src/react/components/pages/predict/predictPage.tsx
+++ b/src/react/components/pages/predict/predictPage.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 import { bindActionCreators } from "redux";
-import { FontIcon, PrimaryButton, Spinner, SpinnerSize, IconButton, TextField, IDropdownOption, Dropdown} from "office-ui-fabric-react";
+import { FontIcon, PrimaryButton, Spinner, SpinnerSize, IconButton, TextField, IDropdownOption, Dropdown} from "@fluentui/react";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
 import IApplicationActions, * as applicationActions from "../../../../redux/actions/applicationActions";
 import IAppTitleActions, * as appTitleActions from "../../../../redux/actions/appTitleActions";

--- a/src/react/components/pages/predict/predictResult.tsx
+++ b/src/react/components/pages/predict/predictResult.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { ITag } from "../../../../models/applicationState";
 import "./predictResult.scss";
 import { getPrimaryGreenTheme } from "../../../../common/themes";
-import { PrimaryButton } from "office-ui-fabric-react";
+import { PrimaryButton } from "@fluentui/react";
 
 export interface IPredictResultProps {
     predictions: { [key: string]: any };

--- a/src/react/components/pages/projectSettings/projectForm.tsx
+++ b/src/react/components/pages/projectSettings/projectForm.tsx
@@ -14,7 +14,7 @@ import "vott-react/dist/css/tagsInput.css";
 import { IConnectionProviderPickerProps } from "../../common/connectionProviderPicker/connectionProviderPicker";
 import { ProjectSettingAction } from "./projectSettingAction";
 import { ProtectedInput } from "../../common/protectedInput/protectedInput";
-import { PrimaryButton } from "office-ui-fabric-react";
+import { PrimaryButton } from "@fluentui/react";
 import { getPrimaryGreenTheme, getPrimaryGreyTheme } from "../../../../common/themes";
 
 // tslint:disable-next-line:no-var-requires

--- a/src/react/components/pages/projectSettings/projectSettingsPage.tsx
+++ b/src/react/components/pages/projectSettings/projectSettingsPage.tsx
@@ -6,7 +6,7 @@ import { Redirect } from "react-router";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { RouteComponentProps } from "react-router-dom";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import ProjectForm from "./projectForm";
 import { constants } from "../../../../common/constants";
 import { strings, interpolate } from "../../../../common/strings";

--- a/src/react/components/pages/train/trainPage.tsx
+++ b/src/react/components/pages/train/trainPage.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 import { bindActionCreators } from "redux";
-import { FontIcon, PrimaryButton, Spinner, SpinnerSize} from "office-ui-fabric-react";
+import { FontIcon, PrimaryButton, Spinner, SpinnerSize} from "@fluentui/react";
 import IProjectActions, * as projectActions from "../../../../redux/actions/projectActions";
 import IApplicationActions, * as applicationActions from "../../../../redux/actions/applicationActions";
 import IAppTitleActions, * as appTitleActions from "../../../../redux/actions/appTitleActions";

--- a/src/react/components/pages/train/trainPanel.tsx
+++ b/src/react/components/pages/train/trainPanel.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon, PrimaryButton } from "office-ui-fabric-react";
+import { FontIcon, PrimaryButton } from "@fluentui/react";
 import TrainRecord, { ITrainRecordProps } from "./trainRecord";
 import { getPrimaryGreyTheme } from "../../../../common/themes";
 

--- a/src/react/components/pages/train/trainRecord.tsx
+++ b/src/react/components/pages/train/trainRecord.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 
 export interface ITrainRecordProps {
     accuracies?: object;

--- a/src/react/components/shell/helpMenu.tsx
+++ b/src/react/components/shell/helpMenu.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { strings } from "../../../common/strings";
 import "./helpMenu.scss";
 

--- a/src/react/components/shell/keyboardShortcuts.tsx
+++ b/src/react/components/shell/keyboardShortcuts.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import React, { useState } from "react";
-import { Modal } from "office-ui-fabric-react/lib/Modal";
-import { FontIcon } from "office-ui-fabric-react";
-import { ICustomizations, Customizer } from "office-ui-fabric-react/lib/Utilities";
+import { Modal } from "@fluentui/react/lib/Modal";
+import { FontIcon } from "@fluentui/react";
+import { ICustomizations, Customizer } from "@fluentui/react/lib/Utilities";
 import { getDarkGreyTheme } from "../../../common/themes";
 import { strings } from "../../../common/strings";
 

--- a/src/react/components/shell/sidebar.tsx
+++ b/src/react/components/shell/sidebar.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import ConditionalNavLink from "../common/conditionalNavLink/conditionalNavLink";
 import { strings } from "../../../common/strings";
 

--- a/src/react/components/shell/statusBar.tsx
+++ b/src/react/components/shell/statusBar.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import React from "react";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { appInfo } from "../../../common/appInfo";
 import "./statusBar.scss";
 

--- a/src/react/components/shell/statusBarMetrics.tsx
+++ b/src/react/components/shell/statusBarMetrics.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import _ from "lodash";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { IProject, AssetState } from "../../../models/applicationState";
 import { strings, interpolate } from "../../../common/strings";
 

--- a/src/react/components/shell/titleBar.tsx
+++ b/src/react/components/shell/titleBar.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { connect } from "react-redux";
-import { FontIcon } from "office-ui-fabric-react";
+import { FontIcon } from "@fluentui/react";
 import { IApplicationState } from "../../../models/applicationState";
 import { PlatformType } from "../../../common/hostProcess";
 import "./titleBar.scss";

--- a/src/react/components/toolbar/toolbarItem.tsx
+++ b/src/react/components/toolbar/toolbarItem.tsx
@@ -7,7 +7,7 @@ import IProjectActions from "../../../redux/actions/projectActions";
 import { IKeyboardContext, KeyboardContext, KeyEventType } from "../common/keyboardManager/keyboardManager";
 import { KeyboardBinding } from "../common/keyboardBinding/keyboardBinding";
 import { ToolbarItemName, ToolbarItemGroup } from "../../../registerToolbar";
-import { IconButton } from "office-ui-fabric-react";
+import { IconButton } from "@fluentui/react";
 
 /**
  * Toolbar Item Metadata

--- a/src/registerIcons.ts
+++ b/src/registerIcons.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license
 
-import { registerIcons as registerIcons_ } from "office-ui-fabric-react";
+import { registerIcons as registerIcons_ } from "@fluentui/react";
 
 export function registerIcons() {
     registerIcons_({


### PR DESCRIPTION
We're moving to Fluent UI.
You will need to run ```npm install``` or ```yarn instal```.
**NO changes in API**
https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/