### PR TITLE
fix: resolve unhandled exceptions and new error message for OCR service

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -629,6 +629,10 @@ export const english: IAppStrings = {
         modelNotFound: {
             title: "Model not found",
             message: "Model \"${modelID}\" not found. Please use another model.",
+        },
+        getOcrError: {
+            title: "Cannot load OCR file",
+            message: "Failed to load from OCR file. Please check your connection or network settings.",
         }
     },
     shareProject: {

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -630,7 +630,12 @@ export const spanish: IAppStrings = {
         modelNotFound: {
             title: "Modelo no encontrado",
             message: "Modelo \"${modelID}\" no encontrado. Por favor use otro modelo.",
+        },
+        getOcrError: {
+            title: "No se puede cargar el archivo OCR",
+            message: "Error al cargar desde el archivo OCR. Verifique su conexión o configuración de red."
         }
+
     },
     shareProject: {
         name: "Compartir proyecto",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -530,6 +530,7 @@ export interface IAppStrings {
         modelCountLimitExceeded: IErrorMetadata,
         requestSendError: IErrorMetadata,
         modelNotFound: IErrorMetadata,
+        getOcrError: IErrorMetadata,
     };
     shareProject: {
         name: string,

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -631,29 +631,32 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
         this.loadingProjectAssets = true;
 
-        const assets: IAsset[] = _(await this.props.actions.loadAssets(this.props.project))
-            .uniqBy((asset) => asset.id)
-            .value();
-
-        if (this.state.assets.length === assets.length
-            && JSON.stringify(this.state.assets) === JSON.stringify(assets)) {
-            this.loadingProjectAssets = false;
-            this.setState({ tagsLoaded: true });
-            return;
-        }
-
-        const lastVisited = assets.find((asset) => asset.id === this.props.project.lastVisitedAssetId);
-
-        this.setState({
-            assets,
-        }, async () => {
-            await this.props.actions.saveProject(this.props.project, false, true);
-            this.setState({ tagsLoaded: true });
-            if (assets.length > 0) {
-                await this.selectAsset(lastVisited ? lastVisited : assets[0]);
+        try {
+            const assets = _(await this.props.actions.loadAssets(this.props.project))
+                .uniqBy((asset) => asset.id)
+                .value();
+            if (this.state.assets.length === assets.length
+                && JSON.stringify(this.state.assets) === JSON.stringify(assets)) {
+                this.loadingProjectAssets = false;
+                this.setState({ tagsLoaded: true });
+                return;
             }
-            this.loadingProjectAssets = false;
-        });
+
+            const lastVisited = assets.find((asset) => asset.id === this.props.project.lastVisitedAssetId);
+
+            this.setState({
+                assets,
+            }, async () => {
+                await this.props.actions.saveProject(this.props.project, false, true);
+                this.setState({ tagsLoaded: true });
+                if (assets.length > 0) {
+                    await this.selectAsset(lastVisited ? lastVisited : assets[0]);
+                }
+                this.loadingProjectAssets = false;
+            });
+        } catch (error) {
+            throw Error(error);
+        }
     }
 
     public loadOcrForNotVisited = async (runForAll?: boolean) => {

--- a/src/services/ocrService.ts
+++ b/src/services/ocrService.ts
@@ -6,6 +6,7 @@ import { IProject } from "../models/applicationState";
 import { IStorageProvider, StorageProviderFactory } from "../providers/storage/storageProviderFactory";
 import { constants } from "../common/constants";
 import ServiceHelper from "./serviceHelper";
+import { strings } from "../common/strings";
 
 export enum OcrStatus {
     loadingFromAzureBlob,
@@ -116,8 +117,12 @@ export class OCRService {
                     this.save(ocrFileName, data);
                     return data;
                 });
-        } catch (err) {
-            ServiceHelper.handleServiceError(err);
+        } catch (error) {
+            if (error.response.status === 400) {
+                throw new Error(strings.errors.getOcrError.message);
+            } else {
+                throw new Error(error);
+            }
         }
     }
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -97,12 +97,14 @@ export default class ProjectService implements IProjectService {
         }
 
         project = await encryptProject(project, securityToken);
-
-        await storageProvider.writeText(
-            `${project.name}${constants.projectFileExtension}`,
-            JSON.stringify(project, null, 4),
-        );
-
+        try {
+            await storageProvider.writeText(
+                `${project.name}${constants.projectFileExtension}`,
+                JSON.stringify(project, null, 4),
+            );
+        } catch (error) {
+            throw new Error(error);
+        }
         return project;
     }
 


### PR DESCRIPTION
When user lose access to storage when they already have opened project we need to show appropriate message. Now, the tool gives misleading error message of "Bad Image URL".
 Also in case of lost access we need handle exceptions.
on issue #440 
<img width="518" alt="Screen Shot 2020-07-31 at 8 08 35 AM" src="https://user-images.githubusercontent.com/64093224/89226083-2e7a5f00-d590-11ea-83c6-955ae56b9602.png">
