### PR TITLE
fix buttons styles - makes them more visible

### DIFF
--- a/src/react/components/pages/editorPage/canvas.scss
+++ b/src/react/components/pages/editorPage/canvas.scss
@@ -19,8 +19,8 @@
   width: 48px;
   height: 48px;
   outline: none;
-  background-color: transparent;
-  border: none;
+  background-color: $darker-1;
+  border: solid 1px $lighter-2;
   color: rgb(0, 161, 241);
 
   &:hover, &.active {

--- a/src/react/components/pages/editorPage/canvas.scss
+++ b/src/react/components/pages/editorPage/canvas.scss
@@ -31,6 +31,9 @@
   &:active {
       background-color: $darker-2;
   }
+  .ms-Icon {
+      font-weight: 600;
+  }
 }
 
 .prev {

--- a/src/react/components/pages/editorPage/canvas.scss
+++ b/src/react/components/pages/editorPage/canvas.scss
@@ -19,14 +19,13 @@
   width: 48px;
   height: 48px;
   outline: none;
-
   background-color: transparent;
   border: none;
-  color: #CCC;
+  color: rgb(0, 161, 241);
 
   &:hover, &.active {
-      background-color: $lighter-2;
-      border: solid 1px $lighter-3;
+    background-color: $darker-2;
+    border: solid 1px $lighter-3;
   }
 
   &:active {


### PR DESCRIPTION

***Before:*** 
<img width="144" alt="Screen Shot 2020-08-28 at 7 51 42 AM" src="https://user-images.githubusercontent.com/64093224/91584568-ade91d00-e907-11ea-863f-558129ae3c38.png">
on hover:
<img width="134" alt="Screen Shot 2020-08-28 at 7 51 48 AM" src="https://user-images.githubusercontent.com/64093224/91584596-bb060c00-e907-11ea-9066-101c76b48106.png">




***After change:***
<img width="84" alt="Screen Shot 2020-08-28 at 8 21 01 AM" src="https://user-images.githubusercontent.com/64093224/91584444-809c6f00-e907-11ea-9df7-ec22361b4464.png">

 on hover:

<img width="96" alt="Screen Shot 2020-08-28 at 8 21 07 AM" src="https://user-images.githubusercontent.com/64093224/91584448-842ff600-e907-11ea-94c1-e9408187a9e7.png">


