### PR TITLE
fix: zoomIn keyboard shortcut for macOS

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -108,7 +108,7 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
                 { role: "togglefullscreen" },
                 { type: "separator", label: "separator2" },
                 { role: "resetZoom", label: "Reset Zoom" },
-                { role: "zoomIn" },
+                { role: "zoomIn", accelerator:  "CmdOrCtrl+="},
                 { role: "zoomOut" },
             ],
         },


### PR DESCRIPTION
Now for zoomIn we use `Cmd` + `=`
fixes #580 