### PR TITLE
refresh currentProjects when load project

### DIFF
--- a/src/redux/reducers/recentProjectsReducer.ts
+++ b/src/redux/reducers/recentProjectsReducer.ts
@@ -22,6 +22,7 @@ export const reducer = (state: IProject[] = [], action: AnyAction): IProject[] =
     let newState: IProject[] = null;
 
     switch (action.type) {
+        case ActionTypes.LOAD_PROJECT_SUCCESS:
         case ActionTypes.SAVE_PROJECT_SUCCESS:
             return [
                 { ...action.payload },


### PR DESCRIPTION
Tt is necessary to refresh currentProjects when open a project.
The project pages (predictPage.tsx, editorPage.tsx, modelCompose.tsx, projectSettings.tsx, trainPage.tsx)  get the project from recentProjects, if the project is changed on blobStorage, but not refresh the currentProjects data, the data may conflicted, 