### PR TITLE
new feature: highlight current tag

### DIFF
--- a/src/react/components/common/imageMap/imageMap.tsx
+++ b/src/react/components/common/imageMap/imageMap.tsx
@@ -43,6 +43,7 @@ interface IImageMapProps {
 
     enableFeatureSelection?: boolean;
     handleFeatureSelect?: (feature: any, isTaggle: boolean, category: FeatureCategory) => void;
+    handleFeatureDoubleClick?: (feature: any, isTaggle: boolean, category: FeatureCategory) => void;
     groupSelectMode?: boolean;
     handleIsPointerOnImage?: (isPointerOnImage: boolean) => void;
     isPointerOnImage?: boolean;
@@ -58,7 +59,7 @@ interface IImageMapProps {
     hoveringFeature?: string;
     onMapReady: () => void;
     handleTableToolTipChange?: (display: string, width: number, height: number, top: number,
-                                left: number, rows: number, columns: number, featureID: string) => void;
+        left: number, rows: number, columns: number, featureID: string) => void;
     addDrawnRegionFeatureProps?: (feature) => void;
     updateFeatureAfterModify?: (features) => any;
 
@@ -84,7 +85,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
     private modify: Modify;
     private snap: Snap;
 
-    private drawnFeatures: Collection = new Collection([], {unique: true});
+    private drawnFeatures: Collection = new Collection([], { unique: true });
     public modifyStartFeatureCoordinates: any = {};
 
     private imageExtent: number[];
@@ -198,7 +199,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
                 onMouseEnter={this.handlePointerEnterImageMap}
                 className="map-wrapper"
             >
-                <div style={{cursor: this.getCursor()}} id="map" className="map" ref={(el) => this.mapElement = el}/>
+                <div style={{ cursor: this.getCursor() }} id="map" className="map" ref={(el) => this.mapElement = el} />
             </div>
         );
     }
@@ -477,7 +478,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
         this.drawRegionVectorLayer?.getSource().clear();
         this.drawnLabelVectorLayer?.getSource().clear();
 
-        this.drawnFeatures = new Collection([], {unique: true});
+        this.drawnFeatures = new Collection([], { unique: true });
 
         this.drawRegionVectorLayer.getSource().on("addfeature", (evt) => {
             this.pushToDrawnFeatures(evt.feature, this.drawnFeatures);
@@ -577,6 +578,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
         this.map.on("pointermove", this.handlePointerMove);
         this.map.on("pointermove", this.handlePointerMoveOnTableIcon);
         this.map.on("pointerup", this.handlePointerUp);
+        this.map.on("dblclick", this.handleDoubleClick);
 
         this.initializeDefaultSelectionMode();
         this.initializeDragPan();
@@ -647,7 +649,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
             return;
         }
 
-        const eventPixel =  this.map.getEventPixel(event.originalEvent);
+        const eventPixel = this.map.getEventPixel(event.originalEvent);
 
         const filter = this.getLayerFilterAtPixel(eventPixel);
 
@@ -661,6 +663,20 @@ export class ImageMap extends React.Component<IImageMapProps> {
                 eventPixel,
                 (feature) => {
                     this.props.handleFeatureSelect(feature, true, filter.category);
+                },
+                filter.layerfilter,
+            );
+        }
+    }
+    private handleDoubleClick = (event: MapBrowserEvent) => {
+        const eventPixel = this.map.getEventPixel(event.originalEvent);
+
+        const filter = this.getLayerFilterAtPixel(eventPixel);
+        if (filter && this.props.handleFeatureDoubleClick) {
+            this.map.forEachFeatureAtPixel(
+                eventPixel,
+                (feature) => {
+                    this.props.handleFeatureDoubleClick(feature, true, filter.category);
                 },
                 filter.layerfilter,
             );
@@ -691,7 +707,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
             this.textVectorLayerFilter);
         if (isPointerOnTextFeature) {
             return {
-                layerfilter : this.textVectorLayerFilter,
+                layerfilter: this.textVectorLayerFilter,
                 category: FeatureCategory.Text,
             };
         }
@@ -719,9 +735,9 @@ export class ImageMap extends React.Component<IImageMapProps> {
     private handlePointerMoveOnTableIcon = (event: MapBrowserEvent) => {
         if (this.props.handleTableToolTipChange) {
             const eventPixel = this.map.getEventPixel(event.originalEvent);
-            const isPointerOnTableIconFeature = this.map.hasFeatureAtPixel(eventPixel,this.tableIconBorderVectorLayerFilter);
+            const isPointerOnTableIconFeature = this.map.hasFeatureAtPixel(eventPixel, this.tableIconBorderVectorLayerFilter);
             if (isPointerOnTableIconFeature) {
-                const features = this.map.getFeaturesAtPixel( eventPixel, this.tableIconBorderVectorLayerFilter);
+                const features = this.map.getFeaturesAtPixel(eventPixel, this.tableIconBorderVectorLayerFilter);
                 if (features.length > 0) {
                     const feature = features[0];
                     if (feature && this.props.hoveringFeature !== feature.get("id")) {
@@ -891,7 +907,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
             source: this.drawRegionVectorLayer.getSource(),
             style: this.props.drawRegionStyler,
             geometryFunction: (coordinates, optGeometry) => {
-                const extent = boundingExtent(/** @type {LineCoordType} */ (coordinates));
+                const extent = boundingExtent(/** @type {LineCoordType} */(coordinates));
                 const boxCoordinates = [[
                     [extent[0], extent[3]],
                     [extent[2], extent[3]],
@@ -1078,8 +1094,8 @@ export class ImageMap extends React.Component<IImageMapProps> {
         this.initializeDrawnRegionLabelLayer();
         this.initializeDrawnRegionLayer();
         return [this.imageLayer, this.textVectorLayer, this.tableBorderVectorLayer, this.tableIconBorderVectorLayer,
-            this.tableIconVectorLayer, this.checkboxVectorLayer, this.drawRegionVectorLayer, this.labelVectorLayer,
-            this.drawnLabelVectorLayer];
+        this.tableIconVectorLayer, this.checkboxVectorLayer, this.drawRegionVectorLayer, this.labelVectorLayer,
+        this.drawnLabelVectorLayer];
     }
 
     private initializePredictLayers = (projection: Projection) => {
@@ -1181,7 +1197,7 @@ export class ImageMap extends React.Component<IImageMapProps> {
 
     private initializeMap = (projection, layers) => {
         this.map = new Map({
-            controls: [] ,
+            controls: [],
             interactions: defaultInteractions({
                 shiftDragZoom: false,
                 doubleClickZoom: false,

--- a/src/react/components/common/tagInput/tagInput.scss
+++ b/src/react/components/common/tagInput/tagInput.scss
@@ -37,7 +37,7 @@
             &-container {
                 overflow-x: visible;
                 overflow-y: auto;
-            };
+            }
         }
 
         &-text-input-row {
@@ -85,6 +85,9 @@
     &-item {
         display: flex;
         flex-direction: row;
+        .tag-content {
+            transition: 1s;
+        }
 
         &-selected {
             .tag-content {
@@ -100,7 +103,12 @@
                 background: $darker-10 !important;
             }
         }
-
+        &-highlight {
+            .tag-content {
+                background-color: $lighter-5 !important;
+                box-shadow:4px 4px 5px $lighter-5;
+            }
+        }
         &-label {
             min-height: 1em;
             display: flex;
@@ -172,7 +180,7 @@
     }
 
     &-item-label {
-        color: #A0A0A0;
+        color: #a0a0a0;
     }
 
     &-item-label:hover {
@@ -224,7 +232,7 @@
                 width: 0.1px;
                 border: 0.5px solid $lighter-2;
                 height: 18px;
-                margin: 0 0.25em
+                margin: 0 0.25em;
             }
 
             &-iconbutton {
@@ -234,7 +242,8 @@
                 padding: 0 0.25em;
                 background-color: transparent;
 
-                &.active, &:hover {
+                &.active,
+                &:hover {
                     background-color: transparent;
                     color: #fff;
                 }
@@ -276,5 +285,5 @@ div.circle-picker-container {
 }
 
 .loading-tag {
-    height: 100%; 
+    height: 100%;
 }

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -516,7 +516,6 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
             tagItemRef.current.classList.add("tag-item-highlight");
             setTimeout(() => {
                 tagItemRef.current.classList.remove("tag-item-highlight");
-                console.log('remove("tag-item-highlight")');
             }, 2000);
         }
     }

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -108,7 +108,7 @@ function filterFormat(type: FieldType): FieldFormat[] {
                 FieldFormat.YMD,
             ];
         default:
-            return [ FieldFormat.NotSpecified ];
+            return [FieldFormat.NotSpecified];
     }
 }
 
@@ -159,7 +159,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
     public render() {
         const dark: ICustomizations = {
             settings: {
-              theme: getDarkTheme(),
+                theme: getDarkTheme(),
             },
             scopedSettings: {},
         };
@@ -185,8 +185,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                         onReorder={this.onReOrder}
                     />
                 </div>
-                {
-                    this.props.tagsLoaded ?
+                {                    this.props.tagsLoaded ?
                     <div className="tag-input-body-container">
                         <div className="tag-input-body">
                             {
@@ -199,7 +198,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                                         onChange={(e) => this.setState({ searchQuery: e.target.value })}
                                         placeholder="Search tags"
                                         autoFocus={true}
-                                        onFocus={() => this.setState({selectedTag: null, tagOperation: TagOperationMode.Rename})}
+                                        onFocus={() => this.setState({ selectedTag: null, tagOperation: TagOperationMode.Rename })}
                                     />
                                     <FontIcon iconName="Search" />
                                 </div>
@@ -238,7 +237,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                         </div>
                     </div>
                     :
-                    <Spinner className="loading-tag" size={SpinnerSize.large}/>
+                    <Spinner className="loading-tag" size={SpinnerSize.large} />
                 }
             </div>
         );
@@ -365,7 +364,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
         const { selectedTag } = this.state;
         const showColorPicker = this.state.tagOperation === TagOperationMode.ColorPicker;
         return (
-            <AlignPortal align={{points: [ "tr", "tl" ]}} target={() => this.headerRef.current}>
+            <AlignPortal align={{ points: ["tr", "tl"] }} target={() => this.headerRef.current}>
                 <div className="tag-input-colorpicker-container">
                     {
                         showColorPicker &&
@@ -485,11 +484,11 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
 
                 if (labelAssigned && ((category === FeatureCategory.DrawnRegion) !== isTagLabelTypeDrawnRegion)) {
                     if (isTagLabelTypeDrawnRegion) {
-                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, {otherCatagory: category}));
+                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, { otherCatagory: category }));
                     } else if (tagCategory === FeatureCategory.Checkbox) {
-                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, {otherCatagory:  FeatureCategory.Checkbox}));
+                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, { otherCatagory: FeatureCategory.Checkbox }));
                     } else {
-                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, {otherCatagory: FeatureCategory.Text}));
+                        toast.warn(interpolate(strings.tags.warnings.notCompatibleWithDrawnRegionTag, { otherCatagory: FeatureCategory.Text }));
                     }
                     return;
                 } else if (tagCategory === category || category === FeatureCategory.DrawnRegion ||
@@ -501,7 +500,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                     onTagClick(tag);
                     deselect = false;
                 } else {
-                    toast.warn(strings.tags.warnings.notCompatibleTagType, {autoClose: 7000});
+                    toast.warn(strings.tags.warnings.notCompatibleTagType, { autoClose: 7000 });
                 }
             }
             this.setState({
@@ -510,14 +509,24 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
             });
         }
     }
-
+    focusTag(tag: string) {
+        const tagItemRef = this.tagItemRefs.get(tag)?.getTagNameRef();
+        if (tagItemRef) {
+            tagItemRef.current.scrollIntoView({ behavior: "smooth" });
+            tagItemRef.current.classList.add("tag-item-highlight");
+            setTimeout(() => {
+                tagItemRef.current.classList.remove("tag-item-highlight");
+                console.log('remove("tag-item-highlight")');
+            }, 2000);
+        }
+    }
     public labelAssigned = (labels: ILabel[], name): boolean => {
-         const label = labels.find((label) => label.label === name ? true : false);
-         if (!label) {
-             return false;
-         } else {
-             return true;
-         }
+        const label = labels.find((label) => label.label === name ? true : false);
+        if (!label) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     public labelAssignedDrawnRegion = (labels: ILabel[], name): boolean => {
@@ -570,11 +579,11 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
 
     private creatTagInput = (value: any) => {
         const newTag: ITag = {
-                name: value,
-                color: getNextColor(this.state.tags),
-                type: FieldType.String,
-                format: FieldFormat.NotSpecified,
-                documentCount: 0,
+            name: value,
+            color: getNextColor(this.state.tags),
+            type: FieldType.String,
+            format: FieldFormat.NotSpecified,
+            documentCount: 0,
         };
         if (newTag.name.length && ![...this.state.tags, newTag].containsDuplicates((t) => t.name)) {
             this.addTag(newTag);
@@ -601,7 +610,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
     }
 
     private onHideContextualMenu = () => {
-        this.setState({tagOperation: TagOperationMode.None});
+        this.setState({ tagOperation: TagOperationMode.None });
     }
 
     private getContextualMenuItems = (): IContextualMenuItem[] => {

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -76,7 +76,7 @@ export interface ITagInputProps {
     onLabelLeave: (label: ILabel) => void;
     /** Function to handle tag change */
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
-    onDoubleClick: (label: ILabel) => void;
+    onDoubleClick?: (label: ILabel) => void;
 }
 
 export interface ITagInputState {

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -76,7 +76,7 @@ export interface ITagInputProps {
     onLabelLeave: (label: ILabel) => void;
     /** Function to handle tag change */
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
-    onDoubleClick?: (label: ILabel) => void;
+    onTagDoubleClick?: (label: ILabel) => void;
 }
 
 export interface ITagInputState {
@@ -399,7 +399,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                 onLabelEnter={this.props.onLabelEnter}
                 onLabelLeave={this.props.onLabelLeave}
                 onTagChanged={this.props.onTagChanged}
-                onDoubleClick={this.props.onDoubleClick}
+                onTagDoubleClick={this.props.onTagDoubleClick}
             />);
     }
 

--- a/src/react/components/common/tagInput/tagInput.tsx
+++ b/src/react/components/common/tagInput/tagInput.tsx
@@ -76,6 +76,7 @@ export interface ITagInputProps {
     onLabelLeave: (label: ILabel) => void;
     /** Function to handle tag change */
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
+    onDoubleClick: (label: ILabel) => void;
 }
 
 export interface ITagInputState {
@@ -398,6 +399,7 @@ export class TagInput extends React.Component<ITagInputProps, ITagInputState> {
                 onLabelEnter={this.props.onLabelEnter}
                 onLabelLeave={this.props.onLabelLeave}
                 onTagChanged={this.props.onTagChanged}
+                onDoubleClick={this.props.onDoubleClick}
             />);
     }
 

--- a/src/react/components/common/tagInput/tagInputItem.tsx
+++ b/src/react/components/common/tagInput/tagInputItem.tsx
@@ -41,7 +41,7 @@ export interface ITagInputItemProps {
     onLabelEnter: (label: ILabel) => void;
     onLabelLeave: (label: ILabel) => void;
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
-    onDoubleClick :(label:ILabel) => void;
+    onDoubleClick?: (label:ILabel) => void;
 }
 
 export interface ITagInputItemState {

--- a/src/react/components/common/tagInput/tagInputItem.tsx
+++ b/src/react/components/common/tagInput/tagInputItem.tsx
@@ -41,6 +41,7 @@ export interface ITagInputItemProps {
     onLabelEnter: (label: ILabel) => void;
     onLabelLeave: (label: ILabel) => void;
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
+    onDoubleClick :(label:ILabel) => void;
 }
 
 export interface ITagInputItemState {
@@ -96,6 +97,7 @@ export default class TagInputItem extends React.Component<ITagInputItemProps, IT
                             style={style}>
                             <div
                                 className={"tag-content pr-2"}
+                                onDoubleClick={this.onNameDoubleClick}
                                 onClick={this.onNameClick}>
                                 {this.getTagContent()}
                             </div>
@@ -137,6 +139,14 @@ export default class TagInputItem extends React.Component<ITagInputItemProps, IT
         const ctrlKey = e.ctrlKey || e.metaKey;
         const altKey = e.altKey;
         this.props.onClick(this.props.tag, { ctrlKey, altKey });
+    }
+
+    private onNameDoubleClick = (e:MouseEvent) => {
+        e.stopPropagation();
+        const { labels } = this.props;
+        if (labels.length > 0) {
+            this.props.onDoubleClick(labels[0]);
+        }
     }
 
     private getItemClassName = () => {

--- a/src/react/components/common/tagInput/tagInputItem.tsx
+++ b/src/react/components/common/tagInput/tagInputItem.tsx
@@ -41,7 +41,7 @@ export interface ITagInputItemProps {
     onLabelEnter: (label: ILabel) => void;
     onLabelLeave: (label: ILabel) => void;
     onTagChanged?: (oldTag: ITag, newTag: ITag) => void;
-    onDoubleClick?: (label:ILabel) => void;
+    onTagDoubleClick?: (label:ILabel) => void;
 }
 
 export interface ITagInputItemState {
@@ -145,7 +145,7 @@ export default class TagInputItem extends React.Component<ITagInputItemProps, IT
         e.stopPropagation();
         const { labels } = this.props;
         if (labels.length > 0) {
-            this.props.onDoubleClick(labels[0]);
+            this.props.onTagDoubleClick(labels[0]);
         }
     }
 

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -55,6 +55,7 @@ export interface ICanvasProps extends React.Props<Canvas> {
     closeTableView?: (state: string) => void;
     onAssetMetadataChanged?: (assetMetadata: IAssetMetadata) => void;
     onSelectedRegionsChanged?: (regions: IRegion[]) => void;
+    onRegionDoubleClick?: (region: IRegion) => void;
     onCanvasRendered?: (canvas: HTMLCanvasElement) => void;
     onRunningOCRStatusChanged?: (isRunning: boolean) => void;
     onRunningAutoLabelingStatusChanged?: (isRunning: boolean) => void;
@@ -266,6 +267,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                     imageHeight={this.state.imageHeight}
                     enableFeatureSelection={!this.state.drawRegionMode && !this.state.groupSelectMode}
                     handleFeatureSelect={this.handleFeatureSelect}
+                    handleFeatureDoubleClick={this.handleFeatureDoubleClick}
                     featureStyler={this.featureStyler}
                     groupSelectMode={this.state.groupSelectMode}
                     handleIsPointerOnImage={this.handleIsPointerOnImage}
@@ -640,6 +642,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             this.props.onSelectedRegionsChanged(selectedRegions);
         }
     }
+    private onRegionDoubleClick = (id: string) => {
+        if (this.props.onRegionDoubleClick) {
+            const region = this.state.currentAsset.regions.find(region=>region.id === id);
+            this.props.onRegionDoubleClick(region);
+        }
+    }
 
     /**
      * Updates regions in both Canvas Tools and the asset data store
@@ -1004,6 +1012,12 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             this.addToSelectedRegions(regionId, feature.get("text"), polygon, category);
         }
         this.redrawAllFeatures();
+    }
+    private handleFeatureDoubleClick = (feature: Feature, isToggle: boolean = true, category: FeatureCategory) => {
+        const regionId = feature.get("id");
+        if (this.isRegionSelected(regionId)) {
+            this.onRegionDoubleClick(regionId);
+        }
     }
 
     private handleMultiSelection = (regionId: any, category: FeatureCategory) => {

--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -2202,4 +2202,11 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         });
         this.imageMap.modifyStartFeatureCoordinates = {};
     }
+
+    async focusOnLabel(label: ILabel) {
+        const { page } = label.value[ 0 ];
+        if (this.state.currentPage !== page) {
+            await this.goToPage(page);
+        }
+    }
 }

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -303,7 +303,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                     onLabelEnter={this.onLabelEnter}
                                     onLabelLeave={this.onLabelLeave}
                                     onTagChanged={this.onTagChanged}
-                                    onDoubleClick={this.onLabelDoubleClicked}
+                                    onTagDoubleClick={this.onLabelDoubleClicked}
                                     ref={this.tagInputRef}
                                 />
                                 <Confirm

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -303,6 +303,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                     onLabelEnter={this.onLabelEnter}
                                     onLabelLeave={this.onLabelLeave}
                                     onTagChanged={this.onTagChanged}
+                                    onDoubleClick={this.onLabelDoubleClicked}
                                     ref={this.tagInputRef}
                                 />
                                 <Confirm
@@ -793,6 +794,10 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     private onLabelEnter = (label: ILabel) => {
         this.setState({ hoveredLabel: label });
+    }
+
+    private onLabelDoubleClicked = (label:ILabel) =>{
+        this.canvas.current.focusOnLabel(label);
     }
 
     private onLabelLeave = (label: ILabel) => {

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -265,6 +265,7 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
                                             onAssetMetadataChanged={this.onAssetMetadataChanged}
                                             onCanvasRendered={this.onCanvasRendered}
                                             onSelectedRegionsChanged={this.onSelectedRegionsChanged}
+                                            onRegionDoubleClick={this.onRegionDoubleClick}
                                             onRunningOCRStatusChanged={this.onCanvasRunningOCRStatusChanged}
                                             onRunningAutoLabelingStatusChanged={this.onCanvasRunningAutoLabelingStatusChanged}
                                             onTagChanged={this.onTagChanged}
@@ -605,6 +606,11 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
 
     private onSelectedRegionsChanged = (selectedRegions: IRegion[]) => {
         this.setState({ selectedRegions });
+    }
+    private onRegionDoubleClick = (region: IRegion) => {
+        if (region.tags?.length > 0) {
+            this.tagInputRef.current.focusTag(region.tags[0]);
+        }
     }
 
     private onTagsChanged = async (tags) => {

--- a/src/redux/reducers/recentProjectsReducer.ts
+++ b/src/redux/reducers/recentProjectsReducer.ts
@@ -22,6 +22,7 @@ export const reducer = (state: IProject[] = [], action: AnyAction): IProject[] =
     let newState: IProject[] = null;
 
     switch (action.type) {
+        case ActionTypes.LOAD_PROJECT_SUCCESS:
         case ActionTypes.SAVE_PROJECT_SUCCESS:
             return [
                 { ...action.payload },


### PR DESCRIPTION
With "highlight current tag", user can quickly locating to the related tag in the TagInput component.
1. select a region in canvas in EditPage
2. double click on the region

the TagInput will scroll to the tag realated to the field you clicked.

![highlight current tag](https://user-images.githubusercontent.com/68627897/94667827-e08c9800-0341-11eb-9012-d21485659572.gif)

double click tag go to label page 
1. double click on a tag whitch realted label not in current page.
the page will switch to the correct page

![double click tag show label page](https://user-images.githubusercontent.com/68627897/95644456-5aaee080-0ae9-11eb-8c67-37bbfc6986e5.gif)
