### PR TITLE
cherry-pick 530545c -- fix: "failed to fetch()" error (#491)

### DIFF
--- a/src/common/localization/en-us.ts
+++ b/src/common/localization/en-us.ts
@@ -293,6 +293,7 @@ export const english: IAppStrings = {
             incorrectFileExtension: {
                 attention: "Attention!",
                 text: "- extension of this file doesn't correspond MIME type. Please check file:",
+                failedToFetch: "Failed to fetch ${fileName} for mime type validation",
             },
         },
         assetError: "Unable to load asset",

--- a/src/common/localization/es-cl.ts
+++ b/src/common/localization/es-cl.ts
@@ -295,6 +295,7 @@ export const spanish: IAppStrings = {
             incorrectFileExtension: {
                 attention: "¡Atención!",
                 text: "-- la extensión de este archivo no corresponde al tipo MIME. Por favor revise el archivo:",
+                failedToFetch: "No se pudo recuperar ${fileName} para la validación del tipo de mímica",
             },
         },
         assetError: "No se puede mostrar el activo",

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -290,6 +290,7 @@ export interface IAppStrings {
             incorrectFileExtension: {
                 attention: string,
                 text: string,
+                failedToFetch: string,
             },
         }
         ,


### PR DESCRIPTION
* add try-catch for fetch()

* use poll function instead try-catch

* style: naming

* fix: poll and resolve for fetched failed

* add try-catch for fetch()

* use poll function instead try-catch

* style: naming

* merge + misc

* deletes unused import

* fix: check for failed fetch promise

* since it's not blocking error - console.err(message) instead 'toast'

* switch to console.err for spooded mime type too

Co-authored-by: stew-ro <v-stewro@microsoft.com>