### PR TITLE
sync ocr and autolabeling state, include necessary tags and lables after running autolabelling

### DIFF
--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -187,8 +187,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
 
     public componentDidUpdate = async (prevProps: Readonly<ICanvasProps>, prevState: Readonly<ICanvasState>) => {
         // Handles asset changing
-        if (this.props.selectedAsset.asset.name !== prevProps.selectedAsset.asset.name
-        ) {
+        if (this.props.selectedAsset.asset.name !== prevProps.selectedAsset.asset.name) {
             this.selectedRegionIds = [];
             this.imageMap.removeAllFeatures();
             this.imageMap.resetAllLayerVisibility();
@@ -209,10 +208,6 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                 await this.loadOcr();
                 this.loadLabelData(asset);
             });
-        } else if (this.props.selectedAsset.asset.isRunningOCR !== prevProps.selectedAsset.asset.isRunningOCR) {
-            this.setState({
-                currentAsset: this.props.selectedAsset
-            });
         } else if (this.isLabelDataChanged(this.props, prevProps)
             || (prevProps.project
                 && this.needUpdateAssetRegionsFromTags(prevProps.project.tags, this.props.project.tags))) {
@@ -224,6 +219,10 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                 this.redrawAllFeatures();
             });
 
+        } else if (this.props.selectedAsset.asset.isRunningOCR !== prevProps.selectedAsset.asset.isRunningOCR) {
+            this.setState({
+                currentAsset: this.props.selectedAsset
+            });
         }
 
         if (this.props.hoveredLabel !== prevProps.hoveredLabel) {


### PR DESCRIPTION
1. Async OCR and AutoLabelling state while running multiple documents
2. Add necessary tags and labels after running autolabelling
![image](https://user-images.githubusercontent.com/73208113/99040297-d823b000-25c3-11eb-8642-32afac4fc2f4.png)
![image](https://user-images.githubusercontent.com/73208113/99040329-e96cbc80-25c3-11eb-8f07-a338b375ff5e.png)
![image](https://user-images.githubusercontent.com/73208113/99040352-f5f11500-25c3-11eb-861a-8376c9fb852f.png)
![image](https://user-images.githubusercontent.com/73208113/99040378-fee1e680-25c3-11eb-936a-734fa25a0aba.png)



