### PR TITLE
Electron improvements for macOS

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,6 +4,7 @@ directories:
   output: releases
   buildResources: app-icons # this is where app-icons is store
 appId: com.microsoft.olft
+productName: Form OCR Testing Tool
 artifactName: '${productName}-${version}-${platform}.${ext}'
 extends: null # need this otherwise it won't use the entry point we set in "main" in package.json
 files:

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -82,11 +82,11 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
     const inputMenu = Menu.buildFromTemplate([
         { role: "undo", accelerator: "CmdOrCtrl+Z" },
         { role: "redo", accelerator: "CmdOrCtrl+Shift+Z" },
-        { type: "separator", label: "separator1"},
+        { type: "separator", label: "separator1" },
         { role: "cut", accelerator: "CmdOrCtrl+X" },
         { role: "copy", accelerator: "CmdOrCtrl+C" },
         { role: "paste", accelerator: "CmdOrCtrl+V" },
-        { type: "separator", label: "separator2"},
+        { type: "separator", label: "separator2" },
         { role: "selectAll", accelerator: "CmdOrCtrl+A" },
     ]);
 
@@ -104,36 +104,13 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
     });
 
     const menuItems: MenuItemConstructorOptions[] = [
-        {
-            label: "File", submenu: [
-                isMac ? { role: "close" } : { role: "quit" }
-            ],
-        },
+        (isMac ? {
+            role: "appMenu",
+        } : {}),
+        { role: "fileMenu" },
         { role: "editMenu" },
-        {
-            label: "View", submenu: [
-                { role: "reload" },
-                { type: "separator", label: "separator1" },
-                { role: "toggleDevTools" },
-                { role: "togglefullscreen" },
-                { type: "separator", label: "separator2" },
-                { role: "resetZoom", label: "Reset Zoom" },
-                { role: "zoomIn", accelerator:  "CmdOrCtrl+="},
-                { role: "zoomOut" },
-            ],
-        },
-        {
-            label: "Window", submenu:
-                (isMac ? [
-                    { role: "minimize" },
-                    { role: "front" },
-                    { type: "separator" },
-                    { role: "window" }
-                ] : [
-                    { role: "minimize" },
-                    { role: "close" }
-                ])
-        },
+        { role: "viewMenu" },
+        { role: "windowMenu" },
     ];
     const menu = Menu.buildFromTemplate(menuItems);
     Menu.setApplicationMenu(menu);

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -3,7 +3,7 @@
 
 import {
     app, ipcMain, BrowserWindow, BrowserWindowConstructorOptions,
-    Menu, MenuItemConstructorOptions,
+    Menu, MenuItemConstructorOptions, shell
 } from "electron";
 import { IpcMainProxy } from "./common/ipcMainProxy";
 import LocalFileSystem from "./providers/storage/localFileSystem";
@@ -50,6 +50,15 @@ async function createWindow() {
 
     mainWindow.once("ready-to-show", () => {
         mainWindow.show();
+    });
+
+    mainWindow.webContents.on("new-window", (event: Event, url: string) => {
+        if (/^http(s)?:\/\//.test(url)) {
+            // Do not open a new Electron browser window, instead open in the user's default browser
+            event.preventDefault();
+            shell.openExternal(url, { activate: true });
+        }
+        // Normal behaviour
     });
 
     ipcMainProxy = new IpcMainProxy(ipcMain, mainWindow);

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -130,6 +130,8 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
     Menu.setApplicationMenu(menu);
 }
 
+app.setName("Form OCR Testing Tool");
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -30,8 +30,8 @@ async function createWindow() {
     };
     windowOptions.webPreferences = {
         nodeIntegration: true,
-        webSecurity: false,
-        enableRemoteModule: true
+        enableRemoteModule: true,
+        webSecurity: true
     };
 
     const staticUrl = process.env.ELECTRON_START_URL || `file:///${__dirname}/index.html`;

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -108,67 +108,11 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
             role: "appMenu",
         } : {}),
         {
-            label: 'File',
-            submenu: [
-                {
-                    label: 'New Project',
-                    accelerator: 'CmdOrCtrl+N',
-                    click: async () => {
-                        console.log('New project')
-                    }
-                },
-                {
-                    label: 'Open Cloud Project',
-                    accelerator: 'CmdOrCtrl+O',
-                    click: async () => {
-                        console.log('Open cloud project')
-                    }
-                },
-                {
-                    label: 'Open Local Project',
-                    accelerator: 'CmdOrCtrl+Shift+O',
-                    click: async () => {
-                        console.log('Open local project')
-                    }
-                },
-                { type: 'separator' },
-                {
-                    label: 'Application Settings',
-                    accelerator: 'CmdOrCtrl+,',
-                    click: async () => {
-                        console.log('Open settings')
-                    }
-                },
-                isMac ? { role: 'close' } : { role: 'quit' },
-            ]
+            role: "fileMenu",
         },
         { role: "editMenu" },
         { role: "viewMenu" },
         { role: "windowMenu" },
-        {
-            role: "help",
-            submenu: [
-                {
-                    label: 'Documentation',
-                    click: async () => {
-                        await shell.openExternal('https://docs.microsoft.com/en-us/azure/cognitive-services/form-recognizer/quickstarts/label-tool?tabs=v2-0                        ')
-                    }
-                },
-                {
-                    label: 'Form OCR Testing Tool on GitHub',
-                    click: async () => {
-                        await shell.openExternal('https://github.com/Microsoft/ocr-form-tools')
-                    }
-                },
-                { type: 'separator' },
-                {
-                    label: 'Report an Issue',
-                    click: async () => {
-                        await shell.openExternal('https://github.com/microsoft/OCR-Form-Tools/issues/new/choose')
-                    }
-                }
-            ]
-        }
     ];
     const menu = Menu.buildFromTemplate(menuItems);
     Menu.setApplicationMenu(menu);

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -127,7 +127,7 @@ app.on("ready", createWindow);
 app.on("window-all-closed", () => {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
-    if (process.platform !== "darwin") {
+    if (!isMac) {
         app.quit();
     }
 });

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -23,7 +23,7 @@ async function createWindow() {
         minWidth: 450,
         minHeight: 100,
         frame: isLinux,
-        titleBarStyle: "hidden",
+        titleBarStyle: "hiddenInset",
         backgroundColor: "#272B30",
         show: false,
         icon: "app-icons/icon.png"
@@ -107,10 +107,68 @@ function registerContextMenu(browserWindow: BrowserWindow): void {
         (isMac ? {
             role: "appMenu",
         } : {}),
-        { role: "fileMenu" },
+        {
+            label: 'File',
+            submenu: [
+                {
+                    label: 'New Project',
+                    accelerator: 'CmdOrCtrl+N',
+                    click: async () => {
+                        console.log('New project')
+                    }
+                },
+                {
+                    label: 'Open Cloud Project',
+                    accelerator: 'CmdOrCtrl+O',
+                    click: async () => {
+                        console.log('Open cloud project')
+                    }
+                },
+                {
+                    label: 'Open Local Project',
+                    accelerator: 'CmdOrCtrl+Shift+O',
+                    click: async () => {
+                        console.log('Open local project')
+                    }
+                },
+                { type: 'separator' },
+                {
+                    label: 'Application Settings',
+                    accelerator: 'CmdOrCtrl+,',
+                    click: async () => {
+                        console.log('Open settings')
+                    }
+                },
+                isMac ? { role: 'close' } : { role: 'quit' },
+            ]
+        },
         { role: "editMenu" },
         { role: "viewMenu" },
         { role: "windowMenu" },
+        {
+            role: "help",
+            submenu: [
+                {
+                    label: 'Documentation',
+                    click: async () => {
+                        await shell.openExternal('https://docs.microsoft.com/en-us/azure/cognitive-services/form-recognizer/quickstarts/label-tool?tabs=v2-0                        ')
+                    }
+                },
+                {
+                    label: 'Form OCR Testing Tool on GitHub',
+                    click: async () => {
+                        await shell.openExternal('https://github.com/Microsoft/ocr-form-tools')
+                    }
+                },
+                { type: 'separator' },
+                {
+                    label: 'Report an Issue',
+                    click: async () => {
+                        await shell.openExternal('https://github.com/microsoft/OCR-Form-Tools/issues/new/choose')
+                    }
+                }
+            ]
+        }
     ];
     const menu = Menu.buildFromTemplate(menuItems);
     Menu.setApplicationMenu(menu);

--- a/src/react/components/shell/titleBar.tsx
+++ b/src/react/components/shell/titleBar.tsx
@@ -104,8 +104,25 @@ export class TitleBar extends React.Component<ITitleBarProps, ITitleBarState> {
             );
         };
 
+        const onDoubleClick = () => {
+            if (!isElectron) {
+                return
+            }
+
+            const window = this.remote.getCurrentWindow();
+            if (!window) return; // No window, nothing to do, although this check doesn't make a whole lot of sense from the renderer process, but you shouldn't handle this from the renderer process
+            if (isMac) { // `getUserDefault` is only available under macOS
+                const action = this.remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string');
+                if (action === 'None') return; // Action disabled entirely, nothing to do
+                if (action === 'Minimize') return window.minimize(); // The user prefers to minimize the window
+            }
+            // Toggling maximization otherwise
+            if (window.isMaximized()) return window.unmaximize();
+            return window.maximize();
+        }
+
         return (
-            <div className="title-bar bg-lighter-3">
+            <div className="title-bar bg-lighter-3" onDoubleClick={onDoubleClick}>
                 {isNotElectronAndMacOrLinux &&
                     <div className="title-bar-icon">
                         {typeof (this.props.icon) === "string" && <FontIcon iconName={this.props.icon} />}


### PR DESCRIPTION
After using FoTT on macOS, I faced some minor issues and decided to dive into the source and make some modifications.

## Changes

- Enable webSecurity, as mentioned in [Do Not Disable WebSecurity
](https://www.electronjs.org/docs/tutorial/security#5-do-not-disable-websecurity) on the Electron security checklist. It should not be required for CORS anymore, but I need to test this a bit more extensively.

- Open external links (for example documentation) in the default browser, instead of in an Electron window where interaction is limited.

- Command + Q to quit an app was not working on macOS, due to a faulty menu item configuration. I did revert back to the default menu items offered by Electron, since there weren't any modifications in the FoTT configuration.

- Set the `productName` and `appName` to 'Form OCR Testing Tool'

- Added maximize / minimize on double click on custom titleBar. (see https://github.com/electron/fiddle/pull/156). Centered the macOS controls.

## Before
<img width="283" alt="Screenshot 2020-11-15 at 16 22 26" src="https://user-images.githubusercontent.com/1424596/99188917-c9bdcb80-275e-11eb-9483-e2ec9f1826d2.png">

<img width="262" alt="Screenshot 2020-11-15 at 17 21 20" src="https://user-images.githubusercontent.com/1424596/99190707-7c465c00-2768-11eb-82d0-5435e9e935ec.png">
(native macOS controls not centered)

## After
<img width="444" alt="Screenshot 2020-11-15 at 16 12 54" src="https://user-images.githubusercontent.com/1424596/99188672-7e56ed80-275d-11eb-96bb-93e1045f5c0c.png">

<img width="425" alt="Screenshot 2020-11-15 at 16 13 04" src="https://user-images.githubusercontent.com/1424596/99188676-80b94780-275d-11eb-9b71-d3b505d301c5.png">

<img width="225" alt="Screenshot 2020-11-15 at 17 30 55" src="https://user-images.githubusercontent.com/1424596/99190711-7ea8b600-2768-11eb-8af2-4c0d0af0e648.png">
(native macOS controls centered)

## Tested
- [x] Tested on macOS
- [ ] Tested on Windows