### PR TITLE
Add GitHub action for Electron

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -5,7 +5,7 @@ name: CI (Electron)
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,0 +1,46 @@
+name: CI (Electron)
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build_electron_app:
+    name: "Build app for"
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        node: [12.14]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}     
+      - name: Install dependencies
+        run: yarn install --network-timeout 1000000 # Change default network timeout to fix Windows-latest issues
+      - name: Build production Electron app
+        run: yarn release      
+        env:
+          CI: false # required since Yarn will fail on warnings in CI environments
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: "binaries"
+          path: |
+            releases/**/*.dmg
+            releases/**/*.snap
+            releases/**/*-win32.exe
+

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -4,6 +4,7 @@ name: CI (Electron)
 # events but only for the master branch
 on:
   push:
+    branches: [ master ]
   pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  pull_request_target:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -4,9 +4,7 @@ name: CI (Electron)
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
+  pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Currently, it is a pain to test a PR for Electron changes. If you want to test it for Windows / Mac for example, you need to compile the binaries on different systems.

This PR adds a GitHub action that will run on every PR to master, where it will compile binaries for macOS, Windows and Linux. Binaries can be downloaded via GitHub Artifacts on every PR.

- node_modules are cached for faster execution of action
- average time is 4 to 10 minutes per build

**Not sure why they are not running on this PR. Could it be that GitHub Actions are disabled in this repo?**