### PR TITLE
fix: handle type error on double click on tag

### DIFF
--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -2389,8 +2389,8 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
     }
 
     async focusOnLabel(label: ILabel) {
-        const { page } = label.value[ 0 ];
-        if (this.state.currentPage !== page) {
+        const page = label.value[ 0 ]?.page;
+        if (page && this.state.currentPage !== page) {
             await this.goToPage(page);
         }
     }


### PR DESCRIPTION
on #781 
When user double click on tag which has no value - the app will through the error.
Fix will handle this error.