### PR TITLE
Fix first time labeling field will crash.

### DIFF
--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -1697,7 +1697,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
                     if (!tableTag) return
                     label = labels.find(label => label?.label === this.getTableLabelFromRegion(tableTag, tableRegion));
                 } else {
-                    if (this.props.selectedAsset.labelData.$schema === constants.labelsSchema) {
+                    if (this.props.selectedAsset.labelData?.$schema === constants.labelsSchema) {
                         label = labels.find(label => this.decodeLabelString(label?.label) === tag);
                     } else {
                         label = labels.find(label => label?.label === tag);

--- a/src/services/assetService.ts
+++ b/src/services/assetService.ts
@@ -446,7 +446,7 @@ export class AssetService {
             if (tagType === FieldType.Object || tagType === FieldType.Array) {
                 labelData.labels = labelData.labels.filter((label) => label.label.split("/")[0].replace(/\~1/g, "/").replace(/\~0/g, "~") !== tagName);
             } else {
-                if (labelData.$schema === constants.labelsSchema) {
+                if (labelData?.$schema === constants.labelsSchema) {
                     labelData.labels = labelData.labels.filter((label) => label.label.replace(/\~1/g, "/").replace(/\~0/g, "~") !== tagName);
                 } else {
                     labelData.labels = labelData.labels.filter((label) => label.label !== tagName);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -249,11 +249,11 @@ export default class ProjectService implements IProjectService {
                         if (!assetLabel || assetLabel === blob) {
                             const content = JSON.parse(await storageProvider.readText(blob)) as ILabelData;
                             content.labels.forEach((label) => {
-                                if (content.$schema === constants.labelsSchema && label.label.split("/").length > 1) {
+                                if (content?.$schema === constants.labelsSchema && label.label.split("/").length > 1) {
                                     return;
                                 }
                                 let labelName;
-                                if (content.$schema === constants.labelsSchema) {
+                                if (content?.$schema === constants.labelsSchema) {
                                     labelName = label.label.replace(/\~1/g, "/").replace(/\~0/g, "~");
                                 } else {
                                     labelName = label.label


### PR DESCRIPTION
Root cause: when first time tagging, labelData is null such that labelData.$schema is causing app crash.

Resolve: handle cases when labelData is null.