### PR TITLE
Initial load/display labeled table content didn't happen

### DIFF
--- a/src/react/components/pages/editorPage/canvas.tsx
+++ b/src/react/components/pages/editorPage/canvas.tsx
@@ -540,7 +540,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
             }
         } else {
             // non-table region, clear table related properties.
-            for(const region of selectedRegions) {
+            for (const region of selectedRegions) {
                 region.isTableRegion = false;
                 delete (region as ITableRegion).rowKey;
                 delete (region as ITableRegion).columnKey;
@@ -1554,7 +1554,7 @@ export default class Canvas extends React.Component<ICanvasProps, ICanvasState> 
         return layers.map((layer) => { return this.decodeLabelString(layer) })
     }
 
-    private convertLabelDataToRegions = (labelData: ILabelData): IRegion[] => {
+    public convertLabelDataToRegions = (labelData: ILabelData): IRegion[] => {
         let regions = [];
         const encodedSchema = labelData?.$schema === constants.labelsSchema;
 

--- a/src/react/components/pages/editorPage/editorPage.tsx
+++ b/src/react/components/pages/editorPage/editorPage.tsx
@@ -766,8 +766,6 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             }
         }
 
-
-
         // Only update asset metadata if state changes or is different
         if (initialState !== asset.state || this.state.selectedAsset !== assetMetadata) {
             if (JSON.stringify(assetMetadata.labelData) !== JSON.stringify(this.state.selectedAsset.labelData)) {
@@ -779,6 +777,8 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
             const newMeta = await this.props.actions.saveAssetMetadata(this.props.project, assetMetadata);
 
             if (this.props.project.lastVisitedAssetId === asset.id) {
+                // Get regions from label data since meta data will not have regions when loaded.
+                newMeta.regions = this.canvas.current?.convertLabelDataToRegions(newMeta.labelData) || [];
                 this.setState({ selectedAsset: newMeta });
             }
             if (this.compareAssetLabelsWithProjectTags(assetMetadata.labelData?.labels, this.props.project.tags)) {
@@ -888,6 +888,9 @@ export default class EditorPage extends React.Component<IEditorPageProps, IEdito
         } catch (err) {
             console.warn("Error computing asset size");
         }
+
+        // Get regions from label data since meta data will not have regions when loaded.
+        assetMetadata.regions = this.canvas.current?.convertLabelDataToRegions(assetMetadata.labelData) || [];
 
         this.setState({
             tableToView: null,


### PR DESCRIPTION
**Scenario.** The table content is read from `regions` which is not set when `selectedAsset` is changed.
**Solution.** Set regions from `labelData` when `selectedAsset` is changed with the loaded metadata.
