### PR TITLE
Change default API version to v2.1-preview3. (#872)

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,7 +9,7 @@ appVersionArr[1] = appVersionArr[1] + "-preview";
 const appVersion = appVersionArr.join(".");
 
 const enableAPIVersionSelection = appInfo.enableAPIVersionSelection;
-const apiVersion = "v2.1-preview.2";
+const apiVersion = "v2.1-preview.3";
 
 /**
  * Constants used throughout application


### PR DESCRIPTION
* Hide predict mode toggle in prod env.

* Change default api version to v2.1-preview.3

Co-authored-by: Simo Hsieh (ManpowerGroup Taiwan) <a-simohsieh@microsoft.com>