### PR TITLE
Handle v3.0 schema on Layout/Prebuilt scenario 

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -7,6 +7,7 @@ const appVersion = appInfo.version;
 const enableAPIVersionSelection = appInfo.enableAPIVersionSelection;
 const enablePredictionResultUpload = appInfo.enablePredictionResultUpload;
 const apiVersion = "v2.1";
+const apiVersionQuery = "api-version=2021-07-30-preview";
 const supportedFieldsSchemas = new Set(["http://www.azure.com/schema/formrecognizer/fields.json", "https://schema.cognitiveservices.azure.com/formrecognizer/2021-03-01/fields.json"]);
 const supportedLabelsSchemas = new Set(["http://www.azure.com/schema/formrecognizer/labels.json", "https://schema.cognitiveservices.azure.com/formrecognizer/2021-03-01/labels.json"]);
 
@@ -17,6 +18,7 @@ export const constants = {
     version: "pubpreview_1.0",
     appVersion,
     apiVersion,
+    apiVersionQuery,
     enableAPIVersionSelection,
     enablePredictionResultUpload,
     projectFormTempKey: "projectForm",

--- a/src/react/components/common/predictionFilePicker/predictionFilePicker.tsx
+++ b/src/react/components/common/predictionFilePicker/predictionFilePicker.tsx
@@ -229,8 +229,8 @@ export class PredictionFilePicker extends React.Component<IPredictionFilePickerP
     private isValidSchema = (jsonData) => {
         if (jsonData && jsonData.analyzeResult) {
             // We should ensure version and documentResults exists.
-            const { version, documentResults } = jsonData.analyzeResult;
-            return !!version && !!documentResults;
+            const { apiVersion, documents } = jsonData.analyzeResult;
+            return !!apiVersion && !!documents;
         }
 
         return false;

--- a/src/react/components/pages/prebuiltPredict/layoutPredictPage.tsx
+++ b/src/react/components/pages/prebuiltPredict/layoutPredictPage.tsx
@@ -619,7 +619,7 @@ export class LayoutPredictPage extends React.Component<Partial<ILayoutPredictPag
     private async getAnalzation(): Promise<any> {
         let endpointURL = url.resolve(
             this.props.prebuiltSettings.serviceURI,
-            `formrecognizer/documentModels/prebuilt:layout/:analyze?api-version=2021-07-30-preview`,
+            `formrecognizer/documentModels/prebuilt:layout/:analyze?${constants.apiVersionQuery}`,
         );
         if (this.state.withPageRange && this.state.pageRangeIsValid) {
             endpointURL += `&${constants.pages}=${this.state.pageRange}`;

--- a/src/react/components/pages/prebuiltPredict/layoutPredictPage.tsx
+++ b/src/react/components/pages/prebuiltPredict/layoutPredictPage.tsx
@@ -619,10 +619,10 @@ export class LayoutPredictPage extends React.Component<Partial<ILayoutPredictPag
     private async getAnalzation(): Promise<any> {
         let endpointURL = url.resolve(
             this.props.prebuiltSettings.serviceURI,
-            `/formrecognizer/${constants.prebuiltServiceVersion}/layout/analyze`,
+            `formrecognizer/documentModels/prebuilt:layout/:analyze?api-version=2021-07-30-preview`,
         );
         if (this.state.withPageRange && this.state.pageRangeIsValid) {
-            endpointURL += `?${constants.pages}=${this.state.pageRange}`;
+            endpointURL += `&${constants.pages}=${this.state.pageRange}`;
         }
         const apiKey = this.props.prebuiltSettings.apiKey;
 

--- a/src/react/components/pages/prebuiltPredict/prebuiltPredictPage.tsx
+++ b/src/react/components/pages/prebuiltPredict/prebuiltPredictPage.tsx
@@ -182,7 +182,7 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
         appTitleActions.setTitle(`${strings.prebuiltPredict.title}`);
         if (prebuiltSettings && prebuiltSettings.serviceURI) {
             this.setState({
-                predictionEndpointUrl: `/formrecognizer/${constants.prebuiltServiceVersion}/prebuilt/${this.state.currentPrebuiltType.servicePath}/analyze?includeTextDetails=true`
+                predictionEndpointUrl: `/formrecognizer/documentModels/prebuilt:${this.state.currentPrebuiltType.servicePath}/:analyze?${constants.apiVersionQuery}&includeTextDetails=true`
             });
         }
     }
@@ -832,7 +832,7 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
         const features = [];
         const imageExtent = [0, 0, this.state.imageWidth, this.state.imageHeight];
         this.tableHelper.drawTables(this.state.currentPage);
-        const isCurrentPage = result => result.page === this.state.currentPage;
+        const isCurrentPage = result => result.pageNumber === this.state.currentPage;
         const ocrForCurrentPage: any = this.getOcrFromAnalyzeResult(this.state.analyzeResult).find(isCurrentPage);
         if (ocrForCurrentPage) {
             const ocrExtent = [0, 0, ocrForCurrentPage.width, ocrForCurrentPage.height];
@@ -840,9 +840,10 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
                 if (field && field.type === "array") {
                     field.valueArray?.forEach(row => createFeature(fieldName, row))
                 } else {
-                    if (_.get(field, "page", null) === this.state.currentPage) {
+                    // Only take first boundingRegion.
+                    if (_.get(field, "boundingRegions[0].pageNumber", null) === this.state.currentPage) {
                         const text = fieldName;
-                        const boundingbox = _.get(field, "boundingBox", []);
+                        const boundingbox = _.get(field, "boundingRegions[0].boundingBox", []);
                         const feature = this.createBoundingBoxVectorFeature(text, boundingbox, imageExtent, ocrExtent);
                         features.push(feature);
                     }
@@ -867,8 +868,8 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
             const blockedFieldNames = ["ReceiptType"];
             return blockedFieldNames.indexOf(fieldName) === -1;
         }
-        const isRootItemObject = obj => obj.hasOwnProperty("text");
-        const docType = _.get(this.state.analyzeResult, "documentResults[0].docType", "");
+        const isRootItemObject = obj => obj.hasOwnProperty("content");
+        const docType = _.get(this.state.analyzeResult, "documents[0].docType", "");
 
         // flat fieldProps of type "array" and "object", and extract root level field props in "object" type
         const flatFieldProps = (displayName, fieldProps) => {
@@ -910,7 +911,7 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
 
     private getPredictionsFromAnalyzeResult(analyzeResult: any) {
         if (analyzeResult) {
-            const documentResults = _.get(analyzeResult, "documentResults", []);
+            const documentResults = _.get(analyzeResult, "documents", []);
             return documentResults.reduce((accFields, documentResult) => ({ ...accFields, ...documentResult.fields }), {});
         } else {
             return {};
@@ -918,14 +919,14 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
     }
 
     private getOcrFromAnalyzeResult(analyzeResult: any) {
-        return _.get(analyzeResult, "readResults", []);
+        return _.get(analyzeResult, "pages", []);
     }
 
     private noOp = () => {
         // no operation
     }
     private onPredictionClick = (predictedItem: any) => {
-        const targetPage = predictedItem.page;
+        const targetPage = _.get(predictedItem, "boundingRegions[0].pageNumber", this.state.currentPage);
         if (Number.isInteger(targetPage) && targetPage !== this.state.currentPage) {
             this.setState({
                 currentPage: targetPage,
@@ -978,7 +979,8 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
     }
 
     private getUpdatedPath(path: string, fromTextArea: boolean): string {
-        const pathTemplate = "/formrecognizer/:prebuiltServiceVersion/prebuilt/:prebuiltType/analyze";
+        const encodedColon = "%3A"; // HACK: Use this to escape match path parameters with colon.
+        const pathTemplate = `/formrecognizer/documentModels/prebuilt${encodedColon}:prebuiltType/${encodedColon}analyze`;
         const normalizedPath = URIUtils.normalizePath(path);
         const pathParams = URIUtils.matchPath(pathTemplate, normalizedPath);
         if (fromTextArea) {
@@ -993,11 +995,10 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
             pathParams["prebuiltType"] = this.state.currentPrebuiltType.servicePath;
         }
         const defaultPathParams = {
-            prebuiltServiceVersion: constants.apiVersion,
             prebuiltType: this.state.currentPrebuiltType.servicePath
         };
-
-        return URIUtils.compilePath(pathTemplate, pathParams, defaultPathParams);
+        // Make encodedColon back to colon.
+        return URIUtils.compilePath(pathTemplate, pathParams, defaultPathParams).replaceAll(encodedColon, ":");
     }
 
     private getUpdatedQueryString(queryString: string, updateEmptyQuery: boolean): string {
@@ -1081,8 +1082,8 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
                 const valueObject = valueArray[i].valueObject || {};
                 const indexColumn = new Cell(i + 1, 0, `#${i + 1}`, null, true);
                 const contentColumns = columnNames.map((columnName, columnIndex) => {
-                    const { text, confidence } = valueObject[columnName] || {};
-                    return new Cell(i + 1, columnIndex + 1, text, confidence);
+                    const { content, confidence } = valueObject[columnName] || {};
+                    return new Cell(i + 1, columnIndex + 1, content, confidence);
                 });
                 matrix.push([indexColumn, ...contentColumns]);
             }

--- a/src/react/components/pages/predict/predictResult.tsx
+++ b/src/react/components/pages/predict/predictResult.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
+import _ from "lodash";
 import React from "react";
 import { ITag } from "../../../../models/applicationState";
 import "./predictResult.scss";
@@ -164,6 +164,7 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
                     </>
             )
         } else {
+            const pageNumber = _.get(item, "boundingRegions[0].pageNumber", undefined);
             return (
                 <div key={key}
                     onClick={() => this.onPredictionClick(item)}
@@ -171,7 +172,7 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
                     onMouseLeave={() => this.onPredictionMouseLeave(item)}>
                     <li className="predictiontag-item" style={style}>
                         <div className={"predictiontag-color"}>
-                            <span>{item.page}</span>
+                            <span>{pageNumber}</span>
                         </div>
                         <div className={"predictiontag-content"}>
                             {this.getPredictionTagContent(item)}
@@ -183,7 +184,7 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
         }
     }
     private renderPredictionItemLabel = (item, postProcessedValue) => {
-        const displayText = item.text || item.valueString;
+        const displayText = item.content || item.valueString;
         return (displayText == null ?
             <li className={postProcessedValue ? "predictiontag-item-label mt-0" : "predictiontag-item-label-null mt-0 mb-1"}>
                 {postProcessedValue ? postProcessedValue : "NULL"}
@@ -248,7 +249,9 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
         const items = this.getItems();
         let csvContent: string = `Key,Value,Confidence,Page,Bounding Box`;
         items.forEach(item => {
-            csvContent += `\n"${item.fieldName}","${item.text ?? ""}",${isNaN(item.confidence) ? "NaN" : (item.confidence * 100).toFixed(2) + "%"},${item.page},"[${item.boundingBox}]"`;
+            const page = _.get(item, "boundingRegions[0].pageNumber");
+            const boundingBox = _.get(item, "boundingRegions[0].boundingBox", []);
+            csvContent += `\n"${item.fieldName}","${item.content ?? ""}",${isNaN(item.confidence) ? "NaN" : (item.confidence * 100).toFixed(2) + "%"},${page},"[${boundingBox}]"`;
         });
         data.push({
             fileName: `${this.props.downloadPrefix}${this.props.downloadResultLabel}-keyvalues.csv`,
@@ -258,17 +261,19 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
         let tableContent: string = "";
         const itemNames = ["fieldName", "text", "confidence", "page", "boundingBox"];
         const getValue = (item: any, fieldName: string) => {
+            const page = _.get(item, "boundingRegions[0].pageNumber");
+            const boundingBox = _.get(item, "boundingRegions[0].boundingBox", []);
             switch (fieldName) {
                 case "fieldName":
                     return `"${item[fieldName]}"`;
                 case "text":
-                    return `"${item[fieldName]}"`;
+                    return `"${item.content}"`;
                 case "confidence":
                     return isNaN(item.confidence) ? "NaN" : (item.confidence * 100).toFixed(2) + "%";
                 case "page":
-                    return item[fieldName];
+                    return page;
                 case "boundingBox":
-                    return `"[${item.boundingBox}]"`;
+                    return `"[${boundingBox}]"`;
                 default:
                     return "";
             }
@@ -347,8 +352,8 @@ export default class PredictResult extends React.Component<IPredictResultProps, 
     }
 
     private getPageNumberFrom = (item: any) => {
-        if (item && item.hasOwnProperty("page")) {
-            return item.page;
+        if (item && _.get(item, "boundingRegions[0].pageNumber")) {
+            return item.boundingRegions[0].pageNumber;
         }
 
         // Get page number from item's children in a recursive way.

--- a/src/services/ocrService.ts
+++ b/src/services/ocrService.ts
@@ -108,9 +108,9 @@ export class OCRService {
                 if (apiVersion === APIVersionPatches.patch5) {
                     body = {
                         source: {
-                        kind: "web",
-                        url: filePath
-                      }
+                            kind: "web",
+                            url: filePath
+                        }
                     };
                 } else {
                     body = { url: filePath };
@@ -118,7 +118,7 @@ export class OCRService {
             }
 
             const endpoint = apiVersion === APIVersionPatches.patch5 ?
-                `/formrecognizer/documentModels/prebuilt:layout/:analyze?api-version=2021-07-30-preview`
+                `/formrecognizer/documentModels/prebuilt:layout/:analyze?${constants.apiVersionQuery}`
                 : `/formrecognizer/${apiVersion}/layout/analyze`;
             const response = await ServiceHelper.postWithAutoRetry(
                 this.project.apiUriBase + endpoint,


### PR DESCRIPTION
- Add `apiVersionQuery` for 3.0 API to `constants`.
- Replace handling logic in `tableHelper`, `layoutHelper`, `predictResult` with v3.0 schema.
    - Use first `boundingRegion` to extract `pageNumber` and `boundingBox` for a field.
- Adjust file validation logic in `predictionFilePicker`.
- Replace endpoints in `layoutPredictPage` and `prebuiltPredictPage`