### PR TITLE
Fix initial endpoint URL on Prebuilt Page

### DIFF
--- a/src/react/components/pages/prebuiltPredict/prebuiltPredictPage.tsx
+++ b/src/react/components/pages/prebuiltPredict/prebuiltPredictPage.tsx
@@ -161,7 +161,7 @@ export class PrebuiltPredictPage extends React.Component<IPrebuiltPredictPagePro
 
         withPageRange: false,
         pageRange: "",
-        predictionEndpointUrl: "/formrecognizer/v2.1/prebuilt/invoice/analyze?includeTextDetails=true",
+        predictionEndpointUrl: `/formrecognizer/documentModels/prebuilt-${this.prebuiltTypes[0].servicePath}:analyze?${constants.apiVersionQuery}`,
 
         liveMode: true,
 


### PR DESCRIPTION
Replace v2.1 endpoint URL with v3.0 one in the constructor of `prebuiltPredictPage`.