### PR TITLE
[FOTT] Remove "/" in model training request when documents are in root folder.

### DIFF
--- a/src/react/components/pages/train/trainPage.tsx
+++ b/src/react/components/pages/train/trainPage.tsx
@@ -413,7 +413,7 @@ export default class TrainPage extends React.Component<ITrainPageProps, ITrainPa
                 source: {
                     kind: "azure.blob",
                     containerUrl: trainSourceURL,
-                    path: `${trainPrefix}/`
+                    path: trainPrefix? `${trainPrefix}/`:''
                 }
             };
         } else {

--- a/src/react/components/pages/train/trainPage.tsx
+++ b/src/react/components/pages/train/trainPage.tsx
@@ -413,7 +413,7 @@ export default class TrainPage extends React.Component<ITrainPageProps, ITrainPa
                 source: {
                     kind: "azure.blob",
                     containerUrl: trainSourceURL,
-                    path: trainPrefix? `${trainPrefix}/`:''
+                    path: trainPrefix ? `${trainPrefix}/` : ""
                 }
             };
         } else {


### PR DESCRIPTION
[FOTT] Remove "/" in model training request when documents are in root folder.

After verification, only version 3.0 has this problem

https://msazure.visualstudio.com/Cognitive%20Services/_workitems/edit/10644514/null