### PR TITLE
hide the prebuilt models in the model compose page.

### DIFF
--- a/src/react/components/pages/modelCompose/modelCompose.tsx
+++ b/src/react/components/pages/modelCompose/modelCompose.tsx
@@ -245,7 +245,10 @@ export default class ModelComposePage extends React.Component<IModelComposePageP
     }
 
     public render() {
-        const { modelList, isCompactMode, columns } = this.state;
+        const {  isCompactMode, columns } = this.state;
+        const modelList = this.state.modelList.filter(item=>{
+            return item.modelId.indexOf('prebuilt-')===-1
+        })
         const dark: ICustomizations = {
             settings: {
                 theme: getDarkGreyTheme(),


### PR DESCRIPTION
fix: hide the prebuilt models in the model compose page.
https://msazure.visualstudio.com/Cognitive%20Services/_workitems/edit/10622828/
